### PR TITLE
ignore *.iml files, not directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #ignore idea configuration
 .idea
-.iml
+*.iml
 target
 
 # ignore eclipse configuration 


### PR DESCRIPTION
Actually, Intellij Idea project creates 'tikv-client.iml' file that should be ignored  by using *.iml