### PR TITLE
rename CodeUtil. TableCodec is much better

### DIFF
--- a/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
 import com.pingcap.tidb.tipb.SelectRequest;
-import com.pingcap.tikv.codec.CodecUtil;
+import com.pingcap.tikv.codec.TableCodec;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.grpc.Kvrpcpb.KvPair;
 import com.pingcap.tikv.grpc.Metapb.Region;
@@ -80,10 +80,10 @@ public class Snapshot {
     public Iterator<Row> select(TiTableInfo table, SelectRequest req, List<TiRange<Long>> ranges) {
         ImmutableList.Builder<TiRange<ByteString>> builder = ImmutableList.builder();
         for (TiRange<Long> r : ranges) {
-            ByteString lowKey = CodecUtil.encodeRowKeyWithHandle(table.getId(), r.getLowValue());
-            ByteString highKey = CodecUtil.encodeRowKeyWithHandle(table.getId(),
+            ByteString startKey = TableCodec.encodeRowKeyWithHandle(table.getId(), r.getLowValue());
+            ByteString endKey = TableCodec.encodeRowKeyWithHandle(table.getId(),
                                                                   Math.max(r.getHighValue() + 1, Long.MAX_VALUE));
-            builder.add(TiRange.createByteStringRange(lowKey, highKey));
+            builder.add(TiRange.createByteStringRange(startKey, endKey));
         }
         List<TiRange<ByteString>> keyRanges = builder.build();
         return new SelectIterator(req, keyRanges, getSession(), regionCache);

--- a/src/main/java/com/pingcap/tikv/codec/LongUtils.java
+++ b/src/main/java/com/pingcap/tikv/codec/LongUtils.java
@@ -16,6 +16,8 @@
 package com.pingcap.tikv.codec;
 
 
+import java.io.IOException;
+
 public class LongUtils {
     public static final byte INT_FLAG = 3;
     public static final byte UINT_FLAG = 4;
@@ -65,7 +67,7 @@ public class LongUtils {
      * @param lVal The data to encode
      */
     public static void writeLong(CodecDataOutput cdo, long lVal) {
-        cdo.writeLong(CodecUtil.flipSignBit(lVal));
+        cdo.writeLong(TableCodec.flipSignBit(lVal));
     }
 
     /**
@@ -109,7 +111,7 @@ public class LongUtils {
      * @return value decoded
      * @exception InvalidCodecFormatException wrong format of binary encoding encountered
      */
-    public static long readLongFully(CodecDataInput cdi) {
+    public static long readLongFully(CodecDataInput cdi) throws IOException {
         byte flag = cdi.readByte();
 
         switch (flag) {
@@ -128,7 +130,7 @@ public class LongUtils {
      * @return value decoded
      * @exception InvalidCodecFormatException wrong format of binary encoding encountered
      */
-    public static long readULongFully(CodecDataInput cdi) {
+    public static long readULongFully(CodecDataInput cdi) throws IOException {
         byte flag = cdi.readByte();
         switch (flag) {
             case UINT_FLAG:
@@ -146,8 +148,8 @@ public class LongUtils {
      * @param cdi source of data
      * @return decoded signed long value
      */
-    public static long readLong(CodecDataInput cdi) {
-        return CodecUtil.flipSignBit(cdi.readLong());
+    public static long readLong(CodecDataInput cdi) throws IOException {
+        return TableCodec.flipSignBit(cdi.readLong());
     }
 
     /**
@@ -155,7 +157,7 @@ public class LongUtils {
      * @param cdi source of data
      * @return decoded unsigned long value
      */
-    public static long readULong(CodecDataInput cdi) {
+    public static long readULong(CodecDataInput cdi) throws IOException {
         return cdi.readLong();
     }
 
@@ -164,7 +166,7 @@ public class LongUtils {
      * @param cdi source of data
      * @return decoded signed long value
      */
-    public static long readVarLong(CodecDataInput cdi) {
+    public static long readVarLong(CodecDataInput cdi) throws IOException {
         long ux = readUVarLong(cdi);
         long x = ux >>> 1;
         if ((ux & 1) != 0) {
@@ -178,7 +180,7 @@ public class LongUtils {
      * @param cdi source of data
      * @return decoded unsigned long value
      */
-    public static long readUVarLong(CodecDataInput cdi) {
+    public static long readUVarLong(CodecDataInput cdi) throws IOException {
         long x = 0;
         int s = 0;
         for (int i = 0; !cdi.eof(); i++) {

--- a/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -1,37 +1,20 @@
-/*
- * Copyright 2017 PingCAP, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.pingcap.tikv.codec;
 
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.util.Pair;
+
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkArgument;
-
-import com.google.protobuf.ByteString;
-import com.pingcap.tikv.meta.ObjectRowImpl;
-import com.pingcap.tikv.meta.Row;
-import com.pingcap.tikv.type.FieldType;
-import com.pingcap.tikv.util.Pair;
 
 // Basically all protobuf ByteString involves buffer copy
 // and might not be a good choice inside codec so we choose to
 // return byte directly for future manipulation
 // But this is not quite clean in case talking with GRPC interfaces
-public class CodecUtil {
+public class TableCodec {
     public static final int ID_LEN = 8;
     public static final int PREFIX_LEN = 1 + ID_LEN;
-    public static final int ROWKEY_LEN = PREFIX_LEN + ID_LEN;
+    public static final int RECORD_ROW_KEY_LEN = PREFIX_LEN + ID_LEN;
 
     public static final byte [] TBL_PREFIX      = new byte[] {'t'};
     public static final byte [] REC_PREFIX_SEP  = new byte[] {'_', 'r'};
@@ -40,25 +23,36 @@ public class CodecUtil {
     private static final long SIGN_MASK = ~Long.MAX_VALUE;
 
     public static void writeRowKey(CodecDataOutput cdo, long tableId, byte[] encodeHandle) {
-        writeTableRecordPrefix(cdo, tableId);
+        appendTableRecordPrefix(cdo, tableId);
         cdo.write(encodeHandle);
     }
+    private static void appendTableRecordPrefix(ByteString buf, long tableId) {
+//        cdo.write(TBL_PREFIX);
+//        LongUtils.writeLong(cdo, tableId);
+//        cdo.write(REC_PREFIX_SEP);
+    }
 
-    private static void writeTableRecordPrefix(CodecDataOutput cdo, long tableId) {
+    private static void appendTableRecordPrefix(CodecDataOutput cdo, long tableId) {
         cdo.write(TBL_PREFIX);
         LongUtils.writeLong(cdo, tableId);
         cdo.write(REC_PREFIX_SEP);
     }
-
+    // encodeRowKeyWithHandle encodes the table id, row handle into a bytes buffer/array
     public static ByteString encodeRowKeyWithHandle(long tableId, long handle) {
+        // make a byte array with lengh recordRowKeyLen + idLen
+        // append Table Record Prefix
+        // EncodeInt
+        // return
+        // RECORD_ROW_KEY_LEN + ID_LEN;
+        // appendTableRecordPrefix(buf, tableId);
         CodecDataOutput cdo = new CodecDataOutput();
-        writeTableRecordPrefix(cdo, tableId);
+        appendTableRecordPrefix(cdo, tableId);
         LongUtils.writeLong(cdo, handle);
         return cdo.toByteString();
     }
 
     public static void writeRowKeyWithHandle(CodecDataOutput cdo, long tableId, long handle) {
-        writeTableRecordPrefix(cdo, tableId);
+        appendTableRecordPrefix(cdo, tableId);
         LongUtils.writeLong(cdo, handle);
     }
 
@@ -67,7 +61,7 @@ public class CodecUtil {
         LongUtils.writeLong(cdo, handle);
     }
 
-    public static Pair<Long, Long> readRecordKey(CodecDataInput cdi) {
+    public static Pair<Long, Long> readRecordKey(CodecDataInput cdi) throws IOException {
         if (!consumeAndMatching(cdi, TBL_PREFIX)) {
             throw new CodecException("Invalid Table Prefix");
         }
@@ -85,7 +79,7 @@ public class CodecUtil {
         return v ^ SIGN_MASK;
     }
 
-    private static boolean consumeAndMatching(CodecDataInput cdi, byte[] prefix) {
+    private static boolean consumeAndMatching(CodecDataInput cdi, byte[] prefix) throws IOException {
         for (byte b : prefix) {
             if (cdi.readByte() != b) {
                 return false;

--- a/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -61,7 +61,7 @@ public class TableCodec {
         LongUtils.writeLong(cdo, handle);
     }
 
-    public static Pair<Long, Long> readRecordKey(CodecDataInput cdi) throws IOException {
+    public static Pair<Long, Long> readRecordKey(CodecDataInput cdi) {
         if (!consumeAndMatching(cdi, TBL_PREFIX)) {
             throw new CodecException("Invalid Table Prefix");
         }


### PR DESCRIPTION
After checking tidb's source code, all relevant functions are in `tablecodec.go` instead of `codec.go`. It would be better if we can keep such mapping relationship. 