### PR TITLE
fix npe issue relate with pd

### DIFF
--- a/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/src/main/java/com/pingcap/tikv/PDClient.java
@@ -297,6 +297,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
 
   @Override
   protected PDStub getAsyncStub() {
+    if(leaderWrapper == null) {
+      throw new GrpcException("pd may be not present");
+    }
     return leaderWrapper
         .getAsyncStub()
         .withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());


### PR DESCRIPTION
Before this PR, npe will be thrown if pd is not present. After this PR, the stacks trace looks like the following:

~~~
Caused by: com.pingcap.tikv.exception.GrpcException: retry is exhausted.
	at com.pingcap.tikv.policy.RetryPolicy.callWithRetry(RetryPolicy.java:77)
	at com.pingcap.tikv.AbstractGRPCClient.callBidiStreamingWithRetry(AbstractGRPCClient.java:129)
	at com.pingcap.tikv.PDClient.getTimestamp(PDClient.java:73)
	at com.pingcap.tikv.TiCluster.getTimestamp(TiCluster.java:39)
	at com.pingcap.tikv.TiCluster.createSnapshot(TiCluster.java:43)
	at com.pingcap.tikv.Main.<clinit>(Main.java:16)
Caused by: com.pingcap.tikv.exception.GrpcException: pd may be not present
	at com.pingcap.tikv.PDClient.getAsyncStub(PDClient.java:296)
	at com.pingcap.tikv.PDClient.getAsyncStub(PDClient.java:59)
	at com.pingcap.tikv.AbstractGRPCClient.lambda$callBidiStreamingWithRetry$2(AbstractGRPCClient.java:131)
	at com.pingcap.tikv.policy.RetryPolicy.callWithRetry(RetryPolicy.java:69)
	... 5 more
ERROR: Non-zero return code '1' from command: Process exited with status 1.
~~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/110)
<!-- Reviewable:end -->
