### PR TITLE
[update]Spelling mistake correction

### DIFF
--- a/src/main/java/com/pingcap/tikv/expression/TiBinaryFunctionExpression.java
+++ b/src/main/java/com/pingcap/tikv/expression/TiBinaryFunctionExpression.java
@@ -18,8 +18,8 @@ package com.pingcap.tikv.expression;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public abstract class TiBinaryFunctionExpresson extends TiFunctionExpression {
-  protected TiBinaryFunctionExpresson(TiExpr lhs, TiExpr rhs) {
+public abstract class TiBinaryFunctionExpression extends TiFunctionExpression {
+  protected TiBinaryFunctionExpression(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }
 

--- a/src/main/java/com/pingcap/tikv/expression/scalar/And.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/And.java
@@ -18,12 +18,12 @@ package com.pingcap.tikv.expression.scalar;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class And extends TiBinaryFunctionExpresson {
+public class And extends TiBinaryFunctionExpression {
   public And(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/BitAnd.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/BitAnd.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class BitAnd extends TiBinaryFunctionExpresson {
+public class BitAnd extends TiBinaryFunctionExpression {
   public BitAnd(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/BitOr.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/BitOr.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class BitOr extends TiBinaryFunctionExpresson {
+public class BitOr extends TiBinaryFunctionExpression {
   public BitOr(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/BitXor.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/BitXor.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class BitXor extends TiBinaryFunctionExpresson {
+public class BitXor extends TiBinaryFunctionExpression {
   public BitXor(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Divide.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Divide.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class Divide extends TiBinaryFunctionExpresson {
+public class Divide extends TiBinaryFunctionExpression {
   public Divide(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Equal.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Equal.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class Equal extends TiBinaryFunctionExpresson {
+public class Equal extends TiBinaryFunctionExpression {
   public Equal(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/GreaterEqual.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/GreaterEqual.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class GreaterEqual extends TiBinaryFunctionExpresson {
+public class GreaterEqual extends TiBinaryFunctionExpression {
   public GreaterEqual(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/GreaterThan.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/GreaterThan.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class GreaterThan extends TiBinaryFunctionExpresson {
+public class GreaterThan extends TiBinaryFunctionExpression {
   public GreaterThan(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/IntDiv.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/IntDiv.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class IntDiv extends TiBinaryFunctionExpresson {
+public class IntDiv extends TiBinaryFunctionExpression {
   public IntDiv(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/LeftShift.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/LeftShift.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class LeftShift extends TiBinaryFunctionExpresson {
+public class LeftShift extends TiBinaryFunctionExpression {
   public LeftShift(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/LessEqual.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/LessEqual.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class LessEqual extends TiBinaryFunctionExpresson {
+public class LessEqual extends TiBinaryFunctionExpression {
   public LessEqual(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/LessThan.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/LessThan.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class LessThan extends TiBinaryFunctionExpresson {
+public class LessThan extends TiBinaryFunctionExpression {
   public LessThan(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Like.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Like.java
@@ -18,13 +18,13 @@ package com.pingcap.tikv.expression.scalar;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.BytesType;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class Like extends TiBinaryFunctionExpresson {
+public class Like extends TiBinaryFunctionExpression {
   public Like(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/LogicalXor.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/LogicalXor.java
@@ -18,12 +18,12 @@ package com.pingcap.tikv.expression.scalar;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class LogicalXor extends TiBinaryFunctionExpresson {
+public class LogicalXor extends TiBinaryFunctionExpression {
   public LogicalXor(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Minus.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Minus.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class Minus extends TiBinaryFunctionExpresson {
+public class Minus extends TiBinaryFunctionExpression {
   public Minus(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Mod.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Mod.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class Mod extends TiBinaryFunctionExpresson {
+public class Mod extends TiBinaryFunctionExpression {
   public Mod(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Multiply.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Multiply.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class Multiply extends TiBinaryFunctionExpresson {
+public class Multiply extends TiBinaryFunctionExpression {
   public Multiply(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/NotEqual.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/NotEqual.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class NotEqual extends TiBinaryFunctionExpresson {
+public class NotEqual extends TiBinaryFunctionExpression {
   public NotEqual(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/NullEqual.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/NullEqual.java
@@ -16,12 +16,12 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 
-public class NullEqual extends TiBinaryFunctionExpresson {
+public class NullEqual extends TiBinaryFunctionExpression {
   public NullEqual(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Or.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Or.java
@@ -18,11 +18,11 @@ package com.pingcap.tikv.expression.scalar;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.IntegerType;
 
-public class Or extends TiBinaryFunctionExpresson {
+public class Or extends TiBinaryFunctionExpression {
   public Or(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/Plus.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/Plus.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class Plus extends TiBinaryFunctionExpresson {
+public class Plus extends TiBinaryFunctionExpression {
   public Plus(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/RightShift.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/RightShift.java
@@ -16,11 +16,11 @@
 package com.pingcap.tikv.expression.scalar;
 
 import com.pingcap.tidb.tipb.ExprType;
-import com.pingcap.tikv.expression.TiBinaryFunctionExpresson;
+import com.pingcap.tikv.expression.TiBinaryFunctionExpression;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.types.DataType;
 
-public class RightShift extends TiBinaryFunctionExpresson {
+public class RightShift extends TiBinaryFunctionExpression {
   public RightShift(TiExpr lhs, TiExpr rhs) {
     super(lhs, rhs);
   }


### PR DESCRIPTION
Change the origin word
'TiBinaryFunctionExpresson'
to
'TiBinaryFunctionExpression'

(letter 'i' added)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/112)
<!-- Reviewable:end -->
