### PR TITLE
Double read support

### DIFF
--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -31,9 +31,9 @@ public class Main {
       conf.setTableScanConcurrency(Integer.parseInt(args[1]));
       conf.setIndexScanBatchSize(Integer.parseInt(args[2]));
     }
-    testUniqueIndex();
+    //testUniqueIndex();
     //tableScan();
-    //indexScan();
+    indexScan();
     session.close();
     System.exit(0);
   }

--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -6,12 +6,11 @@ import com.pingcap.tikv.catalog.Catalog;
 import com.pingcap.tikv.expression.TiColumnRef;
 import com.pingcap.tikv.expression.TiConstant;
 import com.pingcap.tikv.expression.TiExpr;
-import com.pingcap.tikv.expression.scalar.GreaterEqual;
+import com.pingcap.tikv.expression.scalar.GreaterThan;
 import com.pingcap.tikv.meta.TiDBInfo;
 import com.pingcap.tikv.meta.TiIndexInfo;
 import com.pingcap.tikv.meta.TiSelectRequest;
 import com.pingcap.tikv.meta.TiTableInfo;
-import com.pingcap.tikv.operation.IndexScanIterator;
 import com.pingcap.tikv.operation.SchemaInfer;
 import com.pingcap.tikv.predicates.ScanBuilder;
 import com.pingcap.tikv.row.Row;
@@ -21,23 +20,25 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class Main {
-
-  private static TiConfiguration conf =
-      TiConfiguration.createDefault("127.0.0.1:" + 2379);
-  private static TiSession session = TiSession.create(conf);
-  private static Snapshot snapshot = session.createSnapshot();
-
   public static void main(String[] args) throws Exception {
     // May need to save this reference
+    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:" + 2379);
+    if (args.length == 3) {
+      conf.setIndexScanConcurrency(Integer.parseInt(args[0]));
+      conf.setTableScanConcurrency(Integer.parseInt(args[1]));
+      conf.setIndexScanBatchSize(Integer.parseInt(args[2]));
+    }
+
     TiSession session = TiSession.create(conf);
     Catalog cat = session.getCatalog();
     TiDBInfo db = cat.getDatabase("TPCH");
     TiTableInfo table = cat.getTable(db, "lineitem");
     TiIndexInfo index = table.getIndices().get(1);
+    Snapshot snapshot = session.createSnapshot();
 
     List<TiExpr> exprs =
         ImmutableList.of(
-            new GreaterEqual(TiColumnRef.create("L_SHIPDATE", table),
+            new GreaterThan(TiColumnRef.create("L_SHIPDATE", table),
                 TiConstant.create("1993-07-30"))
             // new Equal(TiColumnRef.create("C_CUSTKEY", table), TiConstant.create(1111)),
             // new Equal(TiColumnRef.create("C_NATIONKEY", table), TiConstant.create(6)),
@@ -51,7 +52,7 @@ public class Main {
     selReq
         .addRanges(scanPlan.getKeyRanges())
         .setTableInfo(table)
-        .addRequiredColumn(TiColumnRef.create("L_ORDERKEY", table))
+        .addRequiredColumn(TiColumnRef.create("L_LINENUMBER", table))
         .setStartTs(snapshot.getVersion());
 
     if (scanPlan.isIndexScan()) {
@@ -65,23 +66,22 @@ public class Main {
     //    RangeSplitter.newSplitter(session.getRegionManager())
     //        .splitRangeByRegion(selReq.getRanges());
 
-    IndexScanIterator.old = false;
     System.in.read();
     System.out.println("start");
     Timer t1 = new Timer();
     Iterator<Row> it = snapshot.tableRead(selReq);
 
     SchemaInfer schemaInfer = SchemaInfer.create(selReq);
+    long acc = 0;
     while (it.hasNext()) {
       Row r = it.next();
-      /*for (int i = 0; i < r.fieldCount(); i++) {
-        Object val = r.get(i, schemaInfer.getType(i));
-        System.out.print(val);
-        System.out.print(" ");
+      for (int i = 0; i < r.fieldCount(); i++) {
+        Object v = r.get(i, schemaInfer.getType(i));
+        if (v != null)
+          acc += (Long)v;
       }
-      System.out.print("\n");
-      */
     }
+    System.out.println("acc:" + acc);
     System.out.println("done t1:" + t1.stop(TimeUnit.SECONDS));
     session.close();
     System.exit(0);

--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -1,11 +1,24 @@
 package com.pingcap.tikv;
 
 
+import com.google.common.collect.ImmutableList;
 import com.pingcap.tikv.catalog.Catalog;
+import com.pingcap.tikv.expression.TiColumnRef;
+import com.pingcap.tikv.expression.TiConstant;
+import com.pingcap.tikv.expression.TiExpr;
+import com.pingcap.tikv.expression.scalar.GreaterEqual;
 import com.pingcap.tikv.meta.TiDBInfo;
+import com.pingcap.tikv.meta.TiIndexInfo;
+import com.pingcap.tikv.meta.TiSelectRequest;
 import com.pingcap.tikv.meta.TiTableInfo;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.pingcap.tikv.operation.IndexScanIterator;
+import com.pingcap.tikv.operation.SchemaInfer;
+import com.pingcap.tikv.predicates.ScanBuilder;
+import com.pingcap.tikv.row.Row;
+import com.pingcap.tikv.util.Timer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class Main {
 
@@ -18,19 +31,59 @@ public class Main {
     // May need to save this reference
     TiSession session = TiSession.create(conf);
     Catalog cat = session.getCatalog();
-    TiDBInfo db = cat.getDatabase("test");
-    TiTableInfo table = cat.getTable(db, "t2");
-    Logger log = Logger.getLogger("io.grpc");
-    log.setLevel(Level.WARNING);
+    TiDBInfo db = cat.getDatabase("TPCH");
+    TiTableInfo table = cat.getTable(db, "lineitem");
+    TiIndexInfo index = table.getIndices().get(1);
 
-    cat.listDatabases();
-    while (true) {
-      if (table != null) {
-        System.out.println("exist");
-      } else {
-        System.out.println("deleted");
-      }
-      Thread.currentThread().sleep(1000);
+    List<TiExpr> exprs =
+        ImmutableList.of(
+            new GreaterEqual(TiColumnRef.create("L_SHIPDATE", table),
+                TiConstant.create("1993-07-30"))
+            // new Equal(TiColumnRef.create("C_CUSTKEY", table), TiConstant.create(1111)),
+            // new Equal(TiColumnRef.create("C_NATIONKEY", table), TiConstant.create(6)),
+            //new NotEqual(TiColumnRef.create("c_address", table), TiConstant.create("test"))
+        );
+
+    ScanBuilder scanBuilder = new ScanBuilder();
+    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildScan(exprs, table);
+
+    TiSelectRequest selReq = new TiSelectRequest();
+    selReq
+        .addRanges(scanPlan.getKeyRanges())
+        .setTableInfo(table)
+        .addRequiredColumn(TiColumnRef.create("L_ORDERKEY", table))
+        .setStartTs(snapshot.getVersion());
+
+    if (scanPlan.isIndexScan()) {
+      selReq.setIndexInfo(scanPlan.getIndex());
     }
+    System.out.println(scanPlan.getIndex().toString());
+    System.out.println(selReq.toString());
+
+    //selReq.addWhere(PredicateUtils.mergeCNFExpressions(scanPlan.getFilters()));
+    //List<RangeSplitter.RegionTask> keyWithRegionTasks =
+    //    RangeSplitter.newSplitter(session.getRegionManager())
+    //        .splitRangeByRegion(selReq.getRanges());
+
+    IndexScanIterator.old = false;
+    System.in.read();
+    System.out.println("start");
+    Timer t1 = new Timer();
+    Iterator<Row> it = snapshot.tableRead(selReq);
+
+    SchemaInfer schemaInfer = SchemaInfer.create(selReq);
+    while (it.hasNext()) {
+      Row r = it.next();
+      /*for (int i = 0; i < r.fieldCount(); i++) {
+        Object val = r.get(i, schemaInfer.getType(i));
+        System.out.print(val);
+        System.out.print(" ");
+      }
+      System.out.print("\n");
+      */
+    }
+    System.out.println("done t1:" + t1.stop(TimeUnit.SECONDS));
+    session.close();
+    System.exit(0);
   }
 }

--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -8,10 +8,10 @@ import com.pingcap.tikv.expression.TiConstant;
 import com.pingcap.tikv.expression.TiExpr;
 import com.pingcap.tikv.expression.scalar.GreaterThan;
 import com.pingcap.tikv.meta.TiDBInfo;
-import com.pingcap.tikv.meta.TiIndexInfo;
 import com.pingcap.tikv.meta.TiSelectRequest;
 import com.pingcap.tikv.meta.TiTableInfo;
 import com.pingcap.tikv.operation.SchemaInfer;
+import com.pingcap.tikv.predicates.PredicateUtils;
 import com.pingcap.tikv.predicates.ScanBuilder;
 import com.pingcap.tikv.row.Row;
 import com.pingcap.tikv.util.Timer;
@@ -20,29 +20,125 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class Main {
+  static TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:" + 2379);
+  static TiSession session = TiSession.create(conf);
+  static Catalog cat = session.getCatalog();
+
   public static void main(String[] args) throws Exception {
     // May need to save this reference
-    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:" + 2379);
     if (args.length == 3) {
       conf.setIndexScanConcurrency(Integer.parseInt(args[0]));
       conf.setTableScanConcurrency(Integer.parseInt(args[1]));
       conf.setIndexScanBatchSize(Integer.parseInt(args[2]));
     }
+    testUniqueIndex();
+    //tableScan();
+    //indexScan();
+    session.close();
+    System.exit(0);
+  }
 
-    TiSession session = TiSession.create(conf);
-    Catalog cat = session.getCatalog();
-    TiDBInfo db = cat.getDatabase("TPCH");
-    TiTableInfo table = cat.getTable(db, "lineitem");
-    TiIndexInfo index = table.getIndices().get(1);
+  private static void testUniqueIndex() {
+    TiDBInfo db = cat.getDatabase("test");
+    TiTableInfo table = cat.getTable(db, "test1");
     Snapshot snapshot = session.createSnapshot();
 
+    System.out.println("Index Scan Start");
+    List<TiExpr> exprs =
+        ImmutableList.of(
+            new GreaterThan(TiColumnRef.create("c3", table),
+                TiConstant.create("aa"))
+        );
+
+    ScanBuilder scanBuilder = new ScanBuilder();
+    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildScan(exprs, table);
+
+    TiSelectRequest selReq = new TiSelectRequest();
+    selReq
+        .addRanges(scanPlan.getKeyRanges())
+        .setTableInfo(table)
+        .addRequiredColumn(TiColumnRef.create("c1", table))
+        .addRequiredColumn(TiColumnRef.create("c2", table))
+        .setStartTs(snapshot.getVersion());
+
+    if (scanPlan.isIndexScan()) {
+      selReq.setIndexInfo(scanPlan.getIndex());
+    }
+    System.out.println(scanPlan.getIndex().toString());
+    System.out.println(selReq.toString());
+
+    Timer t1 = new Timer();
+    Iterator<Row> it = snapshot.tableRead(selReq);
+
+    SchemaInfer schemaInfer = SchemaInfer.create(selReq);
+    long acc = 0;
+    while (it.hasNext()) {
+      Row r = it.next();
+      for (int i = 0; i < r.fieldCount(); i++) {
+        Object v = r.get(i, schemaInfer.getType(i));
+        if (v != null)
+          acc += (Long)v;
+      }
+    }
+    System.out.println("acc:" + acc);
+    System.out.println("done t1:" + t1.stop(TimeUnit.SECONDS));
+    System.out.println("");
+  }
+
+  private static void tableScan() throws Exception {
+    TiDBInfo db = cat.getDatabase("TPCH");
+    TiTableInfo table = cat.getTable(db, "lineitem");
+    Snapshot snapshot = session.createSnapshot();
+
+    System.out.println("Table Scan Start");
     List<TiExpr> exprs =
         ImmutableList.of(
             new GreaterThan(TiColumnRef.create("L_SHIPDATE", table),
                 TiConstant.create("1993-07-30"))
-            // new Equal(TiColumnRef.create("C_CUSTKEY", table), TiConstant.create(1111)),
-            // new Equal(TiColumnRef.create("C_NATIONKEY", table), TiConstant.create(6)),
-            //new NotEqual(TiColumnRef.create("c_address", table), TiConstant.create("test"))
+        );
+
+    ScanBuilder scanBuilder = new ScanBuilder();
+    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildTableScan(exprs, table);
+
+    TiSelectRequest selReq = new TiSelectRequest();
+    selReq
+        .addRanges(scanPlan.getKeyRanges())
+        .setTableInfo(table)
+        .addRequiredColumn(TiColumnRef.create("L_LINENUMBER", table))
+        .addRequiredColumn(TiColumnRef.create("L_SHIPDATE", table))
+        .setStartTs(snapshot.getVersion());
+
+    selReq.addWhere(PredicateUtils.mergeCNFExpressions(scanPlan.getFilters()));
+    System.out.println(selReq.toString());
+
+    Timer t1 = new Timer();
+    Iterator<Row> it = snapshot.tableRead(selReq);
+
+    SchemaInfer schemaInfer = SchemaInfer.create(selReq);
+    long acc = 0;
+    while (it.hasNext()) {
+      Row r = it.next();
+      for (int i = 0; i < r.fieldCount(); i++) {
+        Object v = r.get(i, schemaInfer.getType(i));
+        if (v instanceof Long)
+          acc += (Long)v;
+      }
+    }
+    System.out.println("acc:" + acc);
+    System.out.println("done time:" + t1.stop(TimeUnit.SECONDS));
+    System.out.println("");
+  }
+
+  private static void indexScan() throws Exception {
+    TiDBInfo db = cat.getDatabase("TPCH");
+    TiTableInfo table = cat.getTable(db, "lineitem");
+    Snapshot snapshot = session.createSnapshot();
+
+    System.out.println("Index Scan Start");
+    List<TiExpr> exprs =
+        ImmutableList.of(
+            new GreaterThan(TiColumnRef.create("L_SHIPDATE", table),
+                TiConstant.create("1993-07-30"))
         );
 
     ScanBuilder scanBuilder = new ScanBuilder();
@@ -61,13 +157,6 @@ public class Main {
     System.out.println(scanPlan.getIndex().toString());
     System.out.println(selReq.toString());
 
-    //selReq.addWhere(PredicateUtils.mergeCNFExpressions(scanPlan.getFilters()));
-    //List<RangeSplitter.RegionTask> keyWithRegionTasks =
-    //    RangeSplitter.newSplitter(session.getRegionManager())
-    //        .splitRangeByRegion(selReq.getRanges());
-
-    System.in.read();
-    System.out.println("start");
     Timer t1 = new Timer();
     Iterator<Row> it = snapshot.tableRead(selReq);
 
@@ -83,7 +172,6 @@ public class Main {
     }
     System.out.println("acc:" + acc);
     System.out.println("done t1:" + t1.stop(TimeUnit.SECONDS));
-    session.close();
-    System.exit(0);
+    System.out.println("");
   }
 }

--- a/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/src/main/java/com/pingcap/tikv/PDClient.java
@@ -23,6 +23,8 @@ import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.TiClientInternalException;
+import com.pingcap.tikv.kvproto.Kvrpcpb;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.kvproto.Metapb.Store;
 import com.pingcap.tikv.kvproto.PDGrpc;
@@ -89,13 +91,13 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
 
     GetRegionResponse resp = callWithRetry(PDGrpc.METHOD_GET_REGION, request, handler);
-    return new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel);
+    return new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low);
   }
 
   @Override
   public Future<TiRegion> getRegionByKeyAsync(ByteString key) {
     FutureObserver<TiRegion, GetRegionResponse> responseObserver =
-        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel));
+        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low));
     Supplier<GetRegionRequest> request = () ->
         GetRegionRequest.newBuilder().setHeader(header).setRegionKey(key).build();
 
@@ -113,7 +115,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
     GetRegionResponse resp = callWithRetry(PDGrpc.METHOD_GET_REGION_BY_ID, request, handler);
     // Instead of using default leader instance, explicitly set no leader to null
-    return new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel);
+    return new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low);
   }
 
   /**
@@ -127,7 +129,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
   @Override
   public Future<TiRegion> getRegionByIDAsync(long id) {
     FutureObserver<TiRegion, GetRegionResponse> responseObserver =
-        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel));
+        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low));
 
     Supplier<GetRegionByIDRequest> request = () ->
         GetRegionByIDRequest.newBuilder().setHeader(header).setRegionId(id).build();

--- a/src/main/java/com/pingcap/tikv/PDClient.java
+++ b/src/main/java/com/pingcap/tikv/PDClient.java
@@ -91,13 +91,13 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
 
     GetRegionResponse resp = callWithRetry(PDGrpc.METHOD_GET_REGION, request, handler);
-    return new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low);
+    return new TiRegion(resp.getRegion(), resp.getLeader(), conf.getIsolationLevel(), conf.getCommandPriority());
   }
 
   @Override
   public Future<TiRegion> getRegionByKeyAsync(ByteString key) {
     FutureObserver<TiRegion, GetRegionResponse> responseObserver =
-        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low));
+        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), conf.getIsolationLevel(), conf.getCommandPriority()));
     Supplier<GetRegionRequest> request = () ->
         GetRegionRequest.newBuilder().setHeader(header).setRegionKey(key).build();
 
@@ -115,21 +115,13 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
     GetRegionResponse resp = callWithRetry(PDGrpc.METHOD_GET_REGION_BY_ID, request, handler);
     // Instead of using default leader instance, explicitly set no leader to null
-    return new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low);
-  }
-
-  /**
-   * Change default read committed to other isolation level.
-   * @param level is a enum which indicates isolation level.
-   */
-  private void setIsolationLevel(IsolationLevel level) {
-    this.isolationLevel = level;
+    return new TiRegion(resp.getRegion(), resp.getLeader(), conf.getIsolationLevel(), conf.getCommandPriority());
   }
 
   @Override
   public Future<TiRegion> getRegionByIDAsync(long id) {
     FutureObserver<TiRegion, GetRegionResponse> responseObserver =
-        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), isolationLevel, CommandPri.Low));
+        new FutureObserver<>(resp -> new TiRegion(resp.getRegion(), resp.getLeader(), conf.getIsolationLevel(), conf.getCommandPriority()));
 
     Supplier<GetRegionByIDRequest> request = () ->
         GetRegionByIDRequest.newBuilder().setHeader(header).setRegionId(id).build();
@@ -331,7 +323,6 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     PDClient client = null;
     try {
       client = new PDClient(session);
-      client.setIsolationLevel(IsolationLevel.RC);
       client.initCluster();
     } catch (Exception e) {
       if (client != null) {

--- a/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -76,18 +76,24 @@ public class Snapshot {
   }
 
   /**
-   * Issue a select request to TiKV and PD.
+   * Issue a select request
    *
-   * @param selReq is SelectRequest.
+   * @param selReq select request for coporcessor
    * @return a Iterator that contains all result from this select request.
    */
   public Iterator<Row> select(TiSelectRequest selReq) {
     return new SelectIterator(selReq, getSession(), session.getRegionManager(), false);
   }
 
-  public Iterator<Row> selectByIndex(TiSelectRequest selReq) {
+  /**
+   * Issue a select request for index read
+   * @param selReq select request for coporcessor
+   * @param singleRead if perform single read
+   * @return a Iterator that contains all result from this select request.
+   */
+  public Iterator<Row> selectByIndex(TiSelectRequest selReq, boolean singleRead) {
     Iterator<Row> iter = new SelectIterator(selReq, getSession(), session.getRegionManager(), true);
-    return new IndexScanIterator(this, selReq, iter);
+    return new IndexScanIterator(this, selReq, iter, singleRead);
   }
 
   /**
@@ -110,10 +116,10 @@ public class Snapshot {
    * @param task RegionTask of the coprocessor request to send
    * @return Row iterator to iterate over resulting rows
    */
-  public Iterator<Row> selectByIndex(TiSelectRequest req, RegionTask task) {
+  public Iterator<Row> selectByIndex(TiSelectRequest req, RegionTask task, boolean singleRead) {
     Iterator<Row> iter =
         new SelectIterator(req, ImmutableList.of(task), getSession(), true);
-    return new IndexScanIterator(this, req, iter);
+    return new IndexScanIterator(this, req, iter, singleRead);
   }
 
   public Iterator<KvPair> scan(ByteString startKey) {

--- a/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -78,7 +78,7 @@ public class Snapshot {
   /**
    * Issue a table read request
    *
-   * @param selReq select request for coporcessor
+   * @param selReq select request for coprocessor
    * @return a Iterator that contains all result from this select request.
    */
   public Iterator<Row> tableRead(TiSelectRequest selReq) {

--- a/src/main/java/com/pingcap/tikv/Snapshot.java
+++ b/src/main/java/com/pingcap/tikv/Snapshot.java
@@ -17,7 +17,6 @@ package com.pingcap.tikv;
 
 import static com.pingcap.tikv.util.KeyRangeUtils.makeRange;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.exception.TiClientInternalException;
@@ -105,17 +104,17 @@ public class Snapshot {
    * @param task RegionTask of the coprocessor request to send
    * @return Row iterator to iterate over resulting rows
    */
-  public Iterator<Row> tableRead(TiSelectRequest selReq, RegionTask task) {
+  public Iterator<Row> tableRead(TiSelectRequest selReq, List<RegionTask> task) {
     if (selReq.isIndexScan()) {
       Iterator<Long> iter = SelectIterator.getHandleIterator(
           selReq,
-          ImmutableList.of(task),
+          task,
           session);
       return new IndexScanIterator(this, selReq, iter);
     } else {
       return SelectIterator.getRowIterator(
           selReq,
-          ImmutableList.of(task),
+          task,
           session);
     }
   }

--- a/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -36,6 +36,9 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_RETRY_TIMES = 3;
   private static final Class<? extends BackOff> DEF_BACKOFF_CLASS = ExponentialBackOff.class;
   private static final int DEF_MAX_FRAME_SIZE = 268435456 * 2; // 256 * 2 MB
+  private static final int DEF_INDEX_SCAN_BATCH_SIZE = 2000000;
+  private static final int DEF_INDEX_SCAN_CONCURRENCY = 5;
+  private static final int DEF_TABLE_SCAN_CONCURRENCY = 10;
 
   private int retryTimes = DEF_RETRY_TIMES;
   private int timeout = DEF_TIMEOUT;
@@ -47,6 +50,9 @@ public class TiConfiguration implements Serializable {
   private int maxFrameSize = DEF_MAX_FRAME_SIZE;
   private Class<? extends BackOff> backOffClass = DEF_BACKOFF_CLASS;
   private List<HostAndPort> pdAddrs = new ArrayList<>();
+  private int indexScanBatchSize = DEF_INDEX_SCAN_BATCH_SIZE;
+  private int indexScanConcurrency = DEF_INDEX_SCAN_CONCURRENCY;
+  private int tableScanConcurrency = DEF_TABLE_SCAN_CONCURRENCY;
 
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
@@ -158,5 +164,29 @@ public class TiConfiguration implements Serializable {
 
   public void setBackOffClass(Class<? extends BackOff> backOffClass) {
     this.backOffClass = backOffClass;
+  }
+
+  public int getIndexScanBatchSize() {
+    return indexScanBatchSize;
+  }
+
+  public void setIndexScanBatchSize(int indexScanBatchSize) {
+    this.indexScanBatchSize = indexScanBatchSize;
+  }
+
+  public int getIndexScanConcurrency() {
+    return indexScanConcurrency;
+  }
+
+  public void setIndexScanConcurrency(int indexScanConcurrency) {
+    this.indexScanConcurrency = indexScanConcurrency;
+  }
+
+  public int getTableScanConcurrency() {
+    return tableScanConcurrency;
+  }
+
+  public void setTableScanConcurrency(int tableScanConcurrency) {
+    this.tableScanConcurrency = tableScanConcurrency;
   }
 }

--- a/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -41,7 +41,7 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_INDEX_SCAN_BATCH_SIZE = 2000000;
   private static final int DEF_INDEX_SCAN_CONCURRENCY = 5;
   private static final int DEF_TABLE_SCAN_CONCURRENCY = 10;
-  private static final CommandPri DEF_COMMAND_PRIORITY = CommandPri.Normal;
+  private static final CommandPri DEF_COMMAND_PRIORITY = CommandPri.Low;
   private static final IsolationLevel DEF_ISOLATION_LEVEL = IsolationLevel.RC;
 
   private int retryTimes = DEF_RETRY_TIMES;

--- a/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -40,7 +40,7 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_MAX_FRAME_SIZE = 268435456 * 2; // 256 * 2 MB
   private static final int DEF_INDEX_SCAN_BATCH_SIZE = 2000000;
   private static final int DEF_INDEX_SCAN_CONCURRENCY = 5;
-  private static final int DEF_TABLE_SCAN_CONCURRENCY = 10;
+  private static final int DEF_TABLE_SCAN_CONCURRENCY = 512;
   private static final CommandPri DEF_COMMAND_PRIORITY = CommandPri.Low;
   private static final IsolationLevel DEF_ISOLATION_LEVEL = IsolationLevel.RC;
 

--- a/src/main/java/com/pingcap/tikv/TiConfiguration.java
+++ b/src/main/java/com/pingcap/tikv/TiConfiguration.java
@@ -17,6 +17,8 @@ package com.pingcap.tikv;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
+import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.util.BackOff;
 import com.pingcap.tikv.util.ExponentialBackOff;
 import java.io.Serializable;
@@ -39,6 +41,8 @@ public class TiConfiguration implements Serializable {
   private static final int DEF_INDEX_SCAN_BATCH_SIZE = 2000000;
   private static final int DEF_INDEX_SCAN_CONCURRENCY = 5;
   private static final int DEF_TABLE_SCAN_CONCURRENCY = 10;
+  private static final CommandPri DEF_COMMAND_PRIORITY = CommandPri.Normal;
+  private static final IsolationLevel DEF_ISOLATION_LEVEL = IsolationLevel.RC;
 
   private int retryTimes = DEF_RETRY_TIMES;
   private int timeout = DEF_TIMEOUT;
@@ -53,6 +57,8 @@ public class TiConfiguration implements Serializable {
   private int indexScanBatchSize = DEF_INDEX_SCAN_BATCH_SIZE;
   private int indexScanConcurrency = DEF_INDEX_SCAN_CONCURRENCY;
   private int tableScanConcurrency = DEF_TABLE_SCAN_CONCURRENCY;
+  private CommandPri commandPriority = DEF_COMMAND_PRIORITY;
+  private IsolationLevel isolationLevel = DEF_ISOLATION_LEVEL;
 
   public static TiConfiguration createDefault(String pdAddrsStr) {
     Objects.requireNonNull(pdAddrsStr, "pdAddrsStr is null");
@@ -188,5 +194,21 @@ public class TiConfiguration implements Serializable {
 
   public void setTableScanConcurrency(int tableScanConcurrency) {
     this.tableScanConcurrency = tableScanConcurrency;
+  }
+
+  public CommandPri getCommandPriority() {
+    return commandPriority;
+  }
+
+  public void setCommandPriority(CommandPri commandPriority) {
+    this.commandPriority = commandPriority;
+  }
+
+  public IsolationLevel getIsolationLevel() {
+    return isolationLevel;
+  }
+
+  public void setIsolationLevel(IsolationLevel isolationLevel) {
+    this.isolationLevel = isolationLevel;
   }
 }

--- a/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/src/main/java/com/pingcap/tikv/TiSession.java
@@ -16,6 +16,7 @@
 package com.pingcap.tikv;
 
 import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.pingcap.tikv.catalog.Catalog;
 import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.region.RegionManager;
@@ -126,7 +127,9 @@ public class TiSession implements AutoCloseable {
     if (res == null) {
       synchronized (this) {
         if (indexScanThreadPool == null) {
-          indexScanThreadPool = Executors.newFixedThreadPool(conf.getIndexScanConcurrency());
+          indexScanThreadPool = Executors.newFixedThreadPool(
+              conf.getIndexScanConcurrency(),
+              new ThreadFactoryBuilder().setDaemon(true).build());
           res = indexScanThreadPool;
         }
       }
@@ -139,7 +142,9 @@ public class TiSession implements AutoCloseable {
     if (res == null) {
       synchronized (this) {
         if (tableScanThreadPool == null) {
-          tableScanThreadPool = Executors.newFixedThreadPool(conf.getTableScanConcurrency());
+          tableScanThreadPool = Executors.newFixedThreadPool(
+              conf.getTableScanConcurrency(),
+              new ThreadFactoryBuilder().setDaemon(true).build());
           res = tableScanThreadPool;
         }
       }

--- a/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/src/main/java/com/pingcap/tikv/TiSession.java
@@ -155,6 +155,5 @@ public class TiSession implements AutoCloseable {
   public void close() throws Exception {
     getThreadPoolForTableScan().shutdownNow();
     getThreadPoolForIndexScan().shutdownNow();
-    connPool.values().forEach(ManagedChannel::shutdown);
   }
 }

--- a/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/src/main/java/com/pingcap/tikv/TiSession.java
@@ -20,7 +20,10 @@ import com.pingcap.tikv.catalog.Catalog;
 import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.region.RegionManager;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -95,6 +98,9 @@ public class TiSession implements AutoCloseable {
     return res;
   }
 
+  static private final EventLoopGroup elg =
+      new NioEventLoopGroup(32, new DefaultThreadFactory("tikv-client-worker", true));
+
   public synchronized ManagedChannel getChannel(String addressStr) {
     ManagedChannel channel = connPool.get(addressStr);
     if (channel == null) {
@@ -104,12 +110,15 @@ public class TiSession implements AutoCloseable {
       } catch (Exception e) {
         throw new IllegalArgumentException("failed to form address");
       }
+
       // Channel should be lazy without actual connection until first call
       // So a coarse grain lock is ok here
-      channel = ManagedChannelBuilder.forAddress(address.getHostText(), address.getPort())
+      channel = NettyChannelBuilder.forAddress(address.getHostText(), address.getPort())
           .maxInboundMessageSize(conf.getMaxFrameSize())
           .usePlaintext(true)
           .idleTimeout(60, TimeUnit.SECONDS)
+          .eventLoopGroup(elg)
+          .directExecutor()
           .build();
       connPool.put(addressStr, channel);
     }

--- a/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/src/main/java/com/pingcap/tikv/TiSession.java
@@ -122,7 +122,7 @@ public class TiSession implements AutoCloseable {
     return channel;
   }
 
-  public synchronized ExecutorService getThreadPoolForIndexScan() {
+  public ExecutorService getThreadPoolForIndexScan() {
     ExecutorService res = indexScanThreadPool;
     if (res == null) {
       synchronized (this) {
@@ -137,7 +137,7 @@ public class TiSession implements AutoCloseable {
     return res;
   }
 
-  public synchronized ExecutorService getThreadPoolForTableScan() {
+  public ExecutorService getThreadPoolForTableScan() {
     ExecutorService res = tableScanThreadPool;
     if (res == null) {
       synchronized (this) {

--- a/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
+++ b/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
@@ -143,6 +143,23 @@ public class CodecDataInput implements DataInput {
     }
   }
 
+  public final long readPartialLong() {
+    try {
+      byte readBuffer[] = new byte[8];
+      inputStream.read(readBuffer, 0, 8);
+      return (((long) readBuffer[0] << 56) +
+          ((long) (readBuffer[1] & 255) << 48) +
+          ((long) (readBuffer[2] & 255) << 40) +
+          ((long) (readBuffer[3] & 255) << 32) +
+          ((long) (readBuffer[4] & 255) << 24) +
+          ((readBuffer[5] & 255) << 16) +
+          ((readBuffer[6] & 255) << 8) +
+          ((readBuffer[7] & 255) << 0));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   public float readFloat() {
     try {

--- a/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
+++ b/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
@@ -19,6 +19,7 @@ import com.google.protobuf.ByteString;
 import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
+import java.io.IOException;
 
 public class CodecDataInput implements DataInput {
   private final DataInputStream inputStream;
@@ -112,6 +113,16 @@ public class CodecDataInput implements DataInput {
     try {
       return inputStream.readUnsignedShort();
     } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public int readPartialUnsignedShort() {
+    try {
+      byte readBuffer[] = new byte[2];
+      inputStream.read(readBuffer, 0, 2);
+      return ((readBuffer[0] & 0xff) << 8) + ((readBuffer[1] & 0xff) << 0);
+    } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
+++ b/src/main/java/com/pingcap/tikv/codec/CodecDataInput.java
@@ -179,6 +179,17 @@ public class CodecDataInput implements DataInput {
     }
   }
 
+  public int peekByte() {
+    mark(currentPos());
+    int b = readByte() & 0xFF;
+    reset();
+    return b;
+  }
+
+  public int currentPos() {
+    return size() - available();
+  }
+
   public void mark(int givenPos) {
     this.backingStream.mark(givenPos);
   }

--- a/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -19,6 +19,8 @@ import com.google.protobuf.ByteString;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.IntegerType;
 import com.pingcap.tikv.util.Pair;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -88,7 +90,12 @@ public class TableCodec {
         if (v == null) {
           sb.append("NULL");
         } else {
-          sb.append(v.toString());
+          if (v instanceof Date) {
+            SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
+            sb.append(fmt.format((Date)v));
+          } else {
+            sb.append(v.toString());
+          }
         }
       }
     }

--- a/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -166,11 +166,11 @@ public class TableCodec {
     }
     CodecDataOutput cdo = new CodecDataOutput();
     appendTableRecordPrefix(cdo, tableId);
-    byte [] tablePredix = cdo.toBytes();
+    byte [] tablePrefix = cdo.toBytes();
 
     int res = FastByteComparisons.compareTo(
-        tablePredix, 0, tablePredix.length,
-        rowKey, 0, Math.min(rowKey.length, tablePredix.length));
+        tablePrefix, 0, tablePrefix.length,
+        rowKey, 0, Math.min(rowKey.length, tablePrefix.length));
 
     if (res > 0) {
       outResult.status = Status.MIN;
@@ -182,7 +182,7 @@ public class TableCodec {
     }
 
     CodecDataInput cdi = new CodecDataInput(rowKey);
-    cdi.skipBytes(tablePredix.length);
+    cdi.skipBytes(tablePrefix.length);
     if (cdi.available() == 8) {
       outResult.status = Status.EQUAL;
     } else if (cdi.available() < 8) {

--- a/src/main/java/com/pingcap/tikv/codec/TableCodec.java
+++ b/src/main/java/com/pingcap/tikv/codec/TableCodec.java
@@ -70,12 +70,17 @@ public class TableCodec {
       // Here is a hack since range is always on last position
       // If last flag is min flag without any other bytes,
       // then we don't try decoding as bytes type
-      int flag = cdi.peekByte();
       int remaining = cdi.available();
-      if (flag == DataType.indexMinValueFlag() && remaining == 1) {
+      if (remaining == 0) break;
+
+      if (i != 0) {
+        sb.append(", ");
+      }
+      int flag = cdi.peekByte();
+      if (remaining == 1 && flag == DataType.indexMinValueFlag()) {
         sb.append("-INF");
         cdi.skipBytes(1);
-      } else if (flag == DataType.indexMaxValueFlag() && remaining == 1) {
+      } else if (remaining == 1 && flag == DataType.indexMaxValueFlag()) {
         sb.append("+INF");
         cdi.skipBytes(1);
       } else {
@@ -85,9 +90,6 @@ public class TableCodec {
         } else {
           sb.append(v.toString());
         }
-      }
-      if (i != types.size() - 1) {
-        sb.append(",");
       }
     }
 

--- a/src/main/java/com/pingcap/tikv/meta/IndexType.java
+++ b/src/main/java/com/pingcap/tikv/meta/IndexType.java
@@ -18,8 +18,9 @@ package com.pingcap.tikv.meta;
 import com.pingcap.tikv.exception.TiClientInternalException;
 
 public enum IndexType {
-  IndexTypeBtree(0),
-  IndexTypeHash(1);
+  IndexTypeInvalid(0),
+  IndexTypeBtree(1),
+  IndexTypeHash(2);
 
   private final int type;
 
@@ -38,5 +39,15 @@ public enum IndexType {
 
   public int getTypeCode() {
     return type;
+  }
+
+  public String toString() {
+    switch (this.type){
+      case 1:
+        return "BTREE";
+      case 2:
+        return "HASH";
+    }
+    return "Invalid";
   }
 }

--- a/src/main/java/com/pingcap/tikv/meta/IndexType.java
+++ b/src/main/java/com/pingcap/tikv/meta/IndexType.java
@@ -17,6 +17,8 @@ package com.pingcap.tikv.meta;
 
 import com.pingcap.tikv.exception.TiClientInternalException;
 
+// Actually we are not using either real btree or hash index
+// TiDB has its own way for indexing as key value pair.
 public enum IndexType {
   IndexTypeInvalid(0),
   IndexTypeBtree(1),

--- a/src/main/java/com/pingcap/tikv/meta/TiIndexInfo.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiIndexInfo.java
@@ -19,11 +19,13 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.pingcap.tidb.tipb.ColumnInfo;
 import com.pingcap.tidb.tipb.IndexInfo;
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TiIndexInfo implements Serializable {
   private final long id;
@@ -143,5 +145,19 @@ public class TiIndexInfo implements Serializable {
 
   public boolean isFakePrimaryKey() {
     return isFakePrimaryKey;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[%s]",
+        name,
+        Joiner.on(",")
+            .skipNulls()
+            .join(indexColumns
+                .stream()
+                .map(column -> column.getName())
+                .collect(Collectors.toList())
+            )
+    );
   }
 }

--- a/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
@@ -67,7 +67,7 @@ public class TiSelectRequest implements Serializable {
   private TiExpr having;
   private boolean distinct;
 
-  public void bind() {
+  public void resolve() {
     getFields().forEach(expr -> expr.bind(tableInfo));
     getWhere().forEach(expr -> expr.bind(tableInfo));
     getGroupByItems().forEach(item -> item.getExpr().bind(tableInfo));

--- a/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
@@ -368,14 +368,14 @@ public class TiSelectRequest implements Serializable {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     if (tableInfo != null) {
-      sb.append(String.format("[table: %s]", tableInfo.getName()));
+      sb.append(String.format("\n Table: %s", tableInfo.getName()));
     }
     if (indexInfo != null) {
-      sb.append(String.format("[index: %s]", indexInfo.toString()));
+      sb.append(String.format("\n Index: %s", indexInfo.toString()));
     }
 
     if (getRanges().size() != 0) {
-      sb.append(", Ranges: ");
+      sb.append("\n Ranges: ");
       List<String> rangeStrings;
       if (indexInfo == null) {
         rangeStrings = getRanges()
@@ -393,29 +393,30 @@ public class TiSelectRequest implements Serializable {
     }
 
     if (getFields().size() != 0) {
-      sb.append(", Columns: ");
+      sb.append("\n Columns: ");
       sb.append(Joiner.on(", ").skipNulls().join(getFields()));
     }
 
     if (getWhere().size() != 0) {
-      sb.append(", Filter: ");
+      sb.append("\n Filter: ");
       sb.append(Joiner.on(", ").skipNulls().join(getWhere()));
     }
 
     if (getAggregates().size() != 0) {
-      sb.append(", Aggregates: ");
+      sb.append("\n Aggregates: ");
       sb.append(Joiner.on(", ").skipNulls().join(getAggregates()));
     }
 
     if (getGroupByItems().size() != 0) {
-      sb.append(", Group By: ");
+      sb.append("\n Group By: ");
       sb.append(Joiner.on(", ").skipNulls().join(getGroupByItems()));
     }
 
     if (getOrderByItems().size() != 0) {
-      sb.append(", Order By: ");
+      sb.append("\n Order By: ");
       sb.append(Joiner.on(", ").skipNulls().join(getOrderByItems()));
     }
+    sb.append("\n");
     return sb.toString();
   }
 }

--- a/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
@@ -321,7 +321,7 @@ public class TiSelectRequest implements Serializable {
    *
    * @param column is column referred during selectReq
    */
-  public TiSelectRequest addField(TiColumnRef column) {
+  public TiSelectRequest addRequiredColumn(TiColumnRef column) {
     fields.add(requireNonNull(column, "columnRef is null"));
     return this;
   }

--- a/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
@@ -157,6 +157,10 @@ public class TiSelectRequest implements Serializable {
         .build();
   }
 
+  public boolean isIndexScan() {
+    return indexInfo != null;
+  }
+
   public TiSelectRequest setTableInfo(TiTableInfo tableInfo) {
     this.tableInfo = requireNonNull(tableInfo, "tableInfo is null");
     return this;

--- a/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
@@ -370,6 +370,10 @@ public class TiSelectRequest implements Serializable {
       sb.append(tableInfo.toString());
     }
 
+    if (indexInfo != null) {
+      sb.append(String.format("index: [%s] ", indexInfo.toString()));
+    }
+
     for (TiColumnRef ref : fields) {
       sb.append(String.format("ColumnRef:[%s]", ref.toProto().toString()));
     }

--- a/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiTableInfo.java
@@ -61,7 +61,7 @@ public class TiTableInfo implements Serializable {
     this.collate = collate;
     this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     this.pkIsHandle = pkIsHandle;
-    this.indices = indices != null ? ImmutableList.copyOf(indices) : null;
+    this.indices = indices != null ? ImmutableList.copyOf(indices) : ImmutableList.of();
     this.comment = comment;
     this.autoIncId = autoIncId;
     this.maxColumnId = maxColumnId;

--- a/src/main/java/com/pingcap/tikv/operation/ChunkIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/ChunkIterator.java
@@ -36,9 +36,10 @@ public class ChunkIterator implements Iterator<ByteString> {
     ChunkIterator(List<Chunk> chunks, boolean indexScan) {
       // Read and then advance semantics
       this.chunks = chunks;
-      chunkIndex = 0;
-      metaIndex = 0;
-      bufOffset = 0;
+      this.chunkIndex = 0;
+      this.metaIndex = 0;
+      this.bufOffset = 0;
+      this.indexScan = indexScan;
       if (chunks.size() == 0
           || chunks.get(0).getRowsMetaCount() == 0
           || chunks.get(0).getRowsData().size() == 0) {

--- a/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
@@ -17,6 +17,7 @@ package com.pingcap.tikv.operation;
 
 import com.pingcap.tikv.Snapshot;
 import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.meta.TiSelectRequest;
 import com.pingcap.tikv.row.Row;
 import com.pingcap.tikv.util.RangeSplitter;
@@ -24,6 +25,10 @@ import com.pingcap.tikv.util.RangeSplitter.RegionTask;
 import gnu.trove.list.array.TLongArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 
 public class IndexScanIterator implements Iterator<Row> {
@@ -31,6 +36,12 @@ public class IndexScanIterator implements Iterator<Row> {
   private final TiSelectRequest selReq;
   private final Snapshot snapshot;
   private Iterator<Row> rowIterator;
+  final ExecutorService pool = Executors.newFixedThreadPool(10);
+  final ExecutorCompletionService<Iterator<Row>> completionService = new ExecutorCompletionService<>(pool);
+
+  private final int MAX_BATCH = 10000 * 1000;
+  private int batchCount = 0;
+  public static boolean old = true;
 
   public IndexScanIterator(Snapshot snapshot, TiSelectRequest req, Iterator<Long> handleIterator) {
     this.selReq = req;
@@ -38,25 +49,77 @@ public class IndexScanIterator implements Iterator<Row> {
     this.snapshot = snapshot;
   }
 
-  @Override
-  public boolean hasNext() {
+  private TLongArrayList feedBatch() {
+    TLongArrayList handles = new TLongArrayList(MAX_BATCH);
+    while (handleIterator.hasNext()) {
+      handles.add(handleIterator.next());
+      if (handles.size() == MAX_BATCH) {
+        break;
+      }
+    }
+    return handles;
+  }
+
+  public boolean hasNextOld() {
     if (rowIterator == null) {
       TLongArrayList handles = new TLongArrayList(4096);
       while (handleIterator.hasNext()) {
         handles.add(handleIterator.next());
       }
       TiSession session = snapshot.getSession();
-      List<RegionTask> tasks = RangeSplitter
-          .newSplitter(session.getRegionManager())
-          .splitHandlesByRegion(selReq.getTableInfo().getId(), handles);
+      RangeSplitter splitter = RangeSplitter.newSplitter(session.getRegionManager());
 
-      rowIterator = SelectIterator.getRowIterator(selReq, tasks, session);
+      rowIterator = SelectIterator.getRowIterator(
+          selReq,
+          splitter.splitHandlesByRegion(selReq.getTableInfo().getId(), handles),
+          snapshot.getSession());
+    }
+    return rowIterator.hasNext();
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (old) {
+      return hasNextOld();
+    }
+    try {
+      if (rowIterator == null) {
+        TiSession session = snapshot.getSession();
+        while (handleIterator.hasNext()) {
+          TLongArrayList handles = feedBatch();
+          batchCount++;
+          completionService.submit(() -> {
+            List<RegionTask> tasks = RangeSplitter
+                .newSplitter(session.getRegionManager())
+                .splitHandlesByRegion(selReq.getTableInfo().getId(), handles);
+            return SelectIterator.getRowIterator(selReq, tasks, session);
+          });
+        }
+        rowIterator = completionService.take().get();
+        batchCount--;
+      }
+
+      if (rowIterator.hasNext()) {
+        return true;
+      }
+
+      if (batchCount == 0) {
+        return false;
+      }
+      rowIterator = completionService.take().get();
+      batchCount--;
+    } catch (Exception e) {
+      throw new TiClientInternalException("Error reading rows from handle", e);
     }
     return rowIterator.hasNext();
   }
 
   @Override
   public Row next() {
-    return rowIterator.next();
+    if (hasNext()) {
+      return rowIterator.next();
+    } else {
+      throw new NoSuchElementException();
+    }
   }
 }

--- a/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
@@ -45,11 +45,10 @@ public class IndexScanIterator implements Iterator<Row> {
   private List<KeyRange> mergeKeyRangeList(TLongArrayList handles) {
     List<KeyRange> newKeyRanges = new ArrayList<>(handles.size());
     // guard. only allow handles size larger than 1 pursues further.
-    if (handles.size() <= 1) {
-      long handle = handles.get(0);
-      newKeyRanges.add(KeyRangeUtils.makeCoprocRangeWithHandle(selReq.getTableInfo().getId(), handle, handle + 1));
+    if (handles.size() == 0) {
       return newKeyRanges;
     }
+
     // sort handles first
     handles.sort();
     // merge all discrete key ranges.

--- a/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
@@ -36,10 +36,10 @@ public class IndexScanIterator implements Iterator<Row> {
   private final TiSelectRequest selReq;
   private final Snapshot snapshot;
   private Iterator<Row> rowIterator;
-  final ExecutorService pool = Executors.newFixedThreadPool(10);
+  final ExecutorService pool = Executors.newFixedThreadPool(1);
   final ExecutorCompletionService<Iterator<Row>> completionService = new ExecutorCompletionService<>(pool);
 
-  private final int MAX_BATCH = 10000 * 1000;
+  private final int MAX_BATCH = 1000000;
   private int batchCount = 0;
   public static boolean old = true;
 

--- a/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
@@ -54,7 +54,7 @@ public class IndexScanIterator implements Iterator<Row> {
   }
 
   private TLongArrayList feedBatch() {
-    TLongArrayList handles = new TLongArrayList(1000000);
+    TLongArrayList handles = new TLongArrayList(512);
     while (handleIterator.hasNext()) {
       handles.add(handleIterator.next());
       if (batchSize <= handles.size()) {

--- a/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/IndexScanIterator.java
@@ -15,7 +15,6 @@
 
 package com.pingcap.tikv.operation;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.Snapshot;
 import com.pingcap.tikv.codec.KeyUtils;
@@ -23,19 +22,74 @@ import com.pingcap.tikv.codec.TableCodec;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 import com.pingcap.tikv.meta.TiSelectRequest;
 import com.pingcap.tikv.row.Row;
-import java.util.Iterator;
+import gnu.trove.list.array.TLongArrayList;
+import java.util.*;
 
-// A very bad implementation of Index Scanner barely made work
-// TODO: need to make it parallel and group indexes
+
 public class IndexScanIterator implements Iterator<Row> {
-  private final Iterator<Row> iter;
+  private Iterator<Row> iter;
   private final TiSelectRequest selReq;
   private final Snapshot snapshot;
 
-  public IndexScanIterator(Snapshot snapshot, TiSelectRequest req, Iterator<Row> iter) {
+  public IndexScanIterator(Snapshot snapshot, TiSelectRequest req, Iterator<Row> iter, boolean singleRead) {
     this.iter = iter;
     this.selReq = req;
     this.snapshot = snapshot;
+    if (singleRead) {
+      this.iter = singleRead();
+    } else {
+      this.iter = doubleRead();
+    }
+  }
+
+  private List<KeyRange> mergeKeyRangeList(TLongArrayList handles) {
+    List<KeyRange> newKeyRanges = new LinkedList<>();
+    // guard. only allow handles size larger than 2 pursues further.
+    if (handles.size() < 2) {
+      ByteString startKey = TableCodec.encodeRowKeyWithHandle(selReq.getTableInfo().getId(), handles.get(0));
+      ByteString endKey = KeyUtils.getNextKeyInByteOrder(startKey);
+      newKeyRanges.add(KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build());
+      return newKeyRanges;
+    }
+    // sort handles first
+    handles.sort();
+    // merge all discrete key ranges.
+    // e.g.
+    // original key range is [1, 2), [2, 3), [3, 4)
+    // after merge, the result is [1, 4)
+    // original key range is [1, 2), [3, 4), [4, 5)
+    // after merge, the result is [1, 2), [3, 5)
+    TLongArrayList startKeys = new TLongArrayList(64);
+    for (int i = 0; i < handles.size() - 1; i++) {
+      startKeys.add(handles.get(i));
+      long nextStart = handles.get(i + 1);
+      long end = handles.get(i) + 1;
+      if (nextStart <= end) {
+        continue;
+      }
+
+      ByteString startKey = TableCodec.encodeRowKeyWithHandle(selReq.getTableInfo().getId(), startKeys.get(0));
+      ByteString endKey = TableCodec.encodeRowKeyWithHandle(selReq.getTableInfo().getId(), end);
+      newKeyRanges.add(KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build());
+    }
+    return newKeyRanges;
+  }
+
+  private Iterator<Row> doubleRead() {
+    // first read of double read's result are handles.
+    // This is actually keys of our second read.
+    TLongArrayList handles = new TLongArrayList(64);
+    while (iter.hasNext()) {
+      Row r = iter.next();
+      handles.add(r.getLong(0));
+    }
+
+    selReq.resetRanges(mergeKeyRangeList(handles));
+    return snapshot.select(selReq);
+  }
+
+  private Iterator<Row> singleRead() {
+    return iter;
   }
 
   @Override
@@ -45,13 +99,6 @@ public class IndexScanIterator implements Iterator<Row> {
 
   @Override
   public Row next() {
-    Row r = iter.next();
-    long handle = r.getLong(0);
-    ByteString startKey = TableCodec.encodeRowKeyWithHandle(selReq.getTableInfo().getId(), handle);
-    ByteString endKey = ByteString.copyFrom(KeyUtils.prefixNext(startKey.toByteArray()));
-    selReq.resetRanges(
-        ImmutableList.of(KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build()));
-    Iterator<Row> it = snapshot.select(selReq);
-    return it.next();
+    return iter.next();
   }
 }

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -100,7 +100,7 @@ public class SelectIterator implements Iterator<Row> {
     if (chunks == null) {
       return false;
     }
-    chunkIterator = new ChunkIterator(chunks, false);
+    chunkIterator = new ChunkIterator(chunks, indexScan);
     return true;
   }
 

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -34,7 +34,6 @@ import com.pingcap.tikv.row.RowReader;
 import com.pingcap.tikv.row.RowReaderFactory;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.util.RangeSplitter.RegionTask;
-import com.pingcap.tikv.util.Timer;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -134,7 +133,6 @@ public abstract class SelectIterator<T, RawT> implements Iterator<T> {
 
     RegionStoreClient client;
     try {
-      Timer t = new Timer();
       client = RegionStoreClient.create(region, store, session);
       SelectResponse resp = client.coprocess(request, ranges);
       // if resp is null, then indicates eof.

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -17,6 +17,7 @@ package com.pingcap.tikv.operation;
 
 import com.google.protobuf.ByteString;
 import com.pingcap.tidb.tipb.Chunk;
+import com.pingcap.tidb.tipb.SelectRequest;
 import com.pingcap.tidb.tipb.SelectResponse;
 import com.pingcap.tikv.TiSession;
 import com.pingcap.tikv.codec.CodecDataInput;
@@ -24,49 +25,84 @@ import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 import com.pingcap.tikv.kvproto.Metapb.Store;
 import com.pingcap.tikv.meta.TiSelectRequest;
-import com.pingcap.tikv.region.RegionManager;
 import com.pingcap.tikv.region.RegionStoreClient;
 import com.pingcap.tikv.region.TiRegion;
 import com.pingcap.tikv.row.Row;
 import com.pingcap.tikv.row.RowReader;
 import com.pingcap.tikv.row.RowReaderFactory;
 import com.pingcap.tikv.types.DataType;
-import com.pingcap.tikv.types.DataTypeFactory;
-import com.pingcap.tikv.types.Types;
-import com.pingcap.tikv.util.RangeSplitter;
 import com.pingcap.tikv.util.RangeSplitter.RegionTask;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 
-public class SelectIterator implements Iterator<Row> {
+public abstract class SelectIterator<T, RawT> implements Iterator<T> {
 
   protected final TiSession session;
-  private final List<RegionTask> regionTasks;
+  protected final List<RegionTask> regionTasks;
 
-  private ChunkIterator chunkIterator;
+  protected ChunkIterator<RawT> chunkIterator;
   protected int index = 0;
-  private boolean eof = false;
-  private SchemaInfer schemaInfer;
-  private final boolean indexScan;
-  private TiSelectRequest tiReq;
-  private static final DataType[] handleTypes =
-      new DataType[]{DataTypeFactory.of(Types.TYPE_LONG)};
+  protected boolean eof = false;
+  protected SchemaInfer schemaInfer;
+  protected final Function<List<Chunk>, ChunkIterator<RawT>> chunkIteratorFactory;
+  protected final SelectRequest request;
 
-  public SelectIterator(
-      TiSelectRequest req,
-      List<RegionTask> regionTasks,
-      TiSession session,
-      boolean indexScan) {
-    this.regionTasks = regionTasks;
-    this.tiReq = req;
-    this.session = session;
-    this.schemaInfer = SchemaInfer.create(req);
-    this.indexScan = indexScan;
+  public static SelectIterator<Row, ByteString> getRowIterator(TiSelectRequest req,
+                                                   List<RegionTask> regionTasks,
+                                                   TiSession session) {
+    return new SelectIterator<Row, ByteString>(req.buildScan(false),
+                                               regionTasks,
+                                               session,
+                                               SchemaInfer.create(req),
+                                               (chunks) -> ChunkIterator.getRawBytesChunkIterator(chunks)) {
+      @Override
+      public Row next() {
+        if (hasNext()) {
+          ByteString rowData = chunkIterator.next();
+          RowReader reader = RowReaderFactory.createRowReader(new CodecDataInput(rowData));
+          return reader.readRow(this.schemaInfer.getTypes().toArray(new DataType[0]));
+        } else {
+          throw new NoSuchElementException();
+        }
+      }
+    };
   }
 
-  private List<Chunk> createClientAndSendReq(RegionTask regionTask,
-      TiSelectRequest req) {
+  public static SelectIterator<Long, Long> getHandleIterator(TiSelectRequest req,
+      List<RegionTask> regionTasks,
+      TiSession session) {
+    return new SelectIterator<Long, Long>(req.buildScan(true),
+                                          regionTasks,
+                                          session,
+                                          SchemaInfer.create(req),
+                                          (chunks) -> ChunkIterator.getHandleChunkIterator(chunks)) {
+      @Override
+      public Long next() {
+        if (hasNext()) {
+          return chunkIterator.next();
+        } else {
+          throw new NoSuchElementException();
+        }
+      }
+    };
+  }
+
+  public SelectIterator(
+      SelectRequest req,
+      List<RegionTask> regionTasks,
+      TiSession session,
+      SchemaInfer infer,
+      Function<List<Chunk>, ChunkIterator<RawT>> chunkIteratorFactory) {
+    this.regionTasks = regionTasks;
+    this.request = req;
+    this.session = session;
+    this.schemaInfer = infer;
+    this.chunkIteratorFactory = chunkIteratorFactory;
+  }
+
+  private List<Chunk> createClientAndSendReq(RegionTask regionTask) {
     List<KeyRange> ranges = regionTask.getRanges();
     TiRegion region = regionTask.getRegion();
     Store store = regionTask.getStore();
@@ -74,7 +110,7 @@ public class SelectIterator implements Iterator<Row> {
     RegionStoreClient client;
     try {
       client = RegionStoreClient.create(region, store, session);
-      SelectResponse resp = client.coprocess(req.buildScan(indexScan), ranges);
+      SelectResponse resp = client.coprocess(request, ranges);
       // if resp is null, then indicates eof.
       if (resp == null) {
         eof = true;
@@ -86,21 +122,18 @@ public class SelectIterator implements Iterator<Row> {
     }
   }
 
-  public SelectIterator(TiSelectRequest req, TiSession session, RegionManager rm, boolean indexScan) {
-    this(req, RangeSplitter.newSplitter(rm).splitRangeByRegion(req.getRanges()), session, indexScan);
-  }
-
   private boolean readNextRegion() {
     if (eof || index >= regionTasks.size()) {
       return false;
     }
 
     RegionTask regionTask = regionTasks.get(index++);
-    List<Chunk> chunks = createClientAndSendReq(regionTask, this.tiReq);
+    List<Chunk> chunks = createClientAndSendReq(regionTask);
     if (chunks == null) {
       return false;
     }
-    chunkIterator = new ChunkIterator(chunks, indexScan);
+
+    chunkIterator = chunkIteratorFactory.apply(chunks);
     return true;
   }
 
@@ -116,21 +149,5 @@ public class SelectIterator implements Iterator<Row> {
       }
     }
     return true;
-  }
-
-  @Override
-  public Row next() {
-    if (hasNext()) {
-      ByteString rowData = chunkIterator.next();
-      RowReader reader = RowReaderFactory.createRowReader(new CodecDataInput(rowData));
-      // TODO: Make sure if only handle returned
-      if (indexScan) {
-        return reader.readRow(handleTypes);
-      } else {
-        return reader.readRow(this.schemaInfer.getTypes().toArray(new DataType[0]));
-      }
-    } else {
-      throw new NoSuchElementException();
-    }
   }
 }

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -86,8 +86,7 @@ public class SelectIterator implements Iterator<Row> {
     }
   }
 
-  public SelectIterator(TiSelectRequest req, TiSession session, RegionManager rm,
-      boolean indexScan) {
+  public SelectIterator(TiSelectRequest req, TiSession session, RegionManager rm, boolean indexScan) {
     this(req, RangeSplitter.newSplitter(rm).splitRangeByRegion(req.getRanges()), session, indexScan);
   }
 
@@ -101,7 +100,7 @@ public class SelectIterator implements Iterator<Row> {
     if (chunks == null) {
       return false;
     }
-    chunkIterator = new ChunkIterator(chunks);
+    chunkIterator = new ChunkIterator(chunks, false);
     return true;
   }
 

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -126,18 +126,14 @@ public abstract class SelectIterator<T, RawT> implements Iterator<T> {
     Store store = regionTask.getStore();
 
     RegionStoreClient client;
-    try {
-      client = RegionStoreClient.create(region, store, session);
-      SelectResponse resp = client.coprocess(request, ranges);
-      // if resp is null, then indicates eof.
-      if (resp == null) {
-        eof = true;
-        return null;
-      }
-      return resp.getChunksList();
-    } catch (Exception e) {
-      throw new TiClientInternalException("Error Closing Store client.", e);
+    client = RegionStoreClient.create(region, store, session);
+    SelectResponse resp = client.coprocess(request, ranges);
+    // if resp is null, then indicates eof.
+    if (resp == null) {
+      eof = true;
+      return null;
     }
+    return resp.getChunksList();
   }
 
   private boolean readNextRegion() {

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -93,6 +93,7 @@ public class ScanBuilder {
       ScanPlan plan = buildScan(conditions, index, table);
       if (plan.getCost() < minCost) {
         minPlan = plan;
+        minCost = plan.getCost();
       }
     }
     return minPlan;

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -227,7 +227,7 @@ public class ScanBuilder {
           type.encode(cdo, DataType.EncodeType.KEY, ub);
           uKey = cdo.toBytes();
           if (r.upperBoundType().equals(BoundType.CLOSED)) {
-            uKey = KeyUtils.prefixNext(lKey);
+            uKey = KeyUtils.prefixNext(uKey);
           }
         }
 

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -45,15 +45,17 @@ import java.util.Set;
 // TODO: Rethink value binding part since we abstract away datum of TiDB
 public class ScanBuilder {
   public static class ScanPlan {
-    public ScanPlan(List<KeyRange> keyRanges, List<TiExpr> filters, double cost) {
+    public ScanPlan(List<KeyRange> keyRanges, List<TiExpr> filters, TiIndexInfo index, double cost) {
       this.filters = filters;
       this.keyRanges = keyRanges;
       this.cost = cost;
+      this.index = index;
     }
 
     private final List<KeyRange> keyRanges;
     private final List<TiExpr> filters;
     private final double cost;
+    private TiIndexInfo index;
 
     public List<KeyRange> getKeyRanges() {
       return keyRanges;
@@ -65,6 +67,14 @@ public class ScanBuilder {
 
     public double getCost() {
       return cost;
+    }
+
+    public boolean isIndexScan() {
+      return index == null || index.isFakePrimaryKey();
+    }
+
+    public TiIndexInfo getIndex() {
+      return index;
     }
   }
 
@@ -113,7 +123,7 @@ public class ScanBuilder {
       keyRanges = buildIndexScanKeyRange(table, index, irs);
     }
 
-    return new ScanPlan(keyRanges, result.residualConditions, cost);
+    return new ScanPlan(keyRanges, result.residualConditions, index, cost);
   }
 
   private List<KeyRange> buildTableScanKeyRange(TiTableInfo table, List<IndexRange> indexRanges) {

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -80,8 +80,8 @@ public class ScanBuilder {
 
   private static final KeyRange INDEX_FULL_RANGE =
       KeyRange.newBuilder()
-          .setStart(DataType.indexMinValue())
-          .setEnd(DataType.indexMaxValue())
+          .setStart(DataType.encodeIndexMinValue())
+          .setEnd(DataType.encodeIndexMaxValue())
           .build();
 
   // Build scan plan picking access path with lowest cost by estimation

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -93,6 +93,12 @@ public class ScanBuilder {
     return minPlan;
   }
 
+  public ScanPlan buildTableScan(List<TiExpr> conditions, TiTableInfo table) {
+    TiIndexInfo pkIndex = TiIndexInfo.generateFakePrimaryKeyIndex(table);
+    ScanPlan plan = buildScan(conditions, pkIndex, table);
+    return plan;
+  }
+
   public ScanPlan buildScan(List<TiExpr> conditions, TiIndexInfo index, TiTableInfo table) {
     requireNonNull(table, "Table cannot be null to encoding keyRange");
     requireNonNull(conditions, "conditions cannot be null to encoding keyRange");

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -70,7 +70,7 @@ public class ScanBuilder {
     }
 
     public boolean isIndexScan() {
-      return index == null || index.isFakePrimaryKey();
+      return index != null && !index.isFakePrimaryKey();
     }
 
     public TiIndexInfo getIndex() {

--- a/src/main/java/com/pingcap/tikv/predicates/SelectivityCalculator.java
+++ b/src/main/java/com/pingcap/tikv/predicates/SelectivityCalculator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.predicates;
+
+
+import com.pingcap.tikv.expression.TiExpr;
+import com.pingcap.tikv.expression.scalar.Equal;
+import com.pingcap.tikv.expression.scalar.GreaterEqual;
+import com.pingcap.tikv.expression.scalar.GreaterThan;
+import com.pingcap.tikv.expression.scalar.LessEqual;
+import com.pingcap.tikv.expression.scalar.LessThan;
+import com.pingcap.tikv.expression.scalar.NullEqual;
+
+public class SelectivityCalculator {
+  public static final double SELECTION_FACTOR = 0.8;
+  public static final double EQUAL_RATE = 1000;
+  public static final double LESS_RATE = 3;
+
+  public static double calcPseudoSelectivity(Iterable<TiExpr> exprs) {
+    double minFactor = SELECTION_FACTOR;
+    for (TiExpr expr : exprs) {
+      if (expr instanceof Equal || expr instanceof NullEqual) {
+        minFactor = Math.min(minFactor, 1.0 / EQUAL_RATE);
+      } else if (expr instanceof GreaterEqual ||
+          expr instanceof GreaterThan ||
+          expr instanceof LessEqual ||
+          expr instanceof LessThan) {
+        minFactor = Math.min(minFactor, 1.0 / LESS_RATE);
+      }
+    }
+    return minFactor;
+  }
+}

--- a/src/main/java/com/pingcap/tikv/predicates/SelectivityCalculator.java
+++ b/src/main/java/com/pingcap/tikv/predicates/SelectivityCalculator.java
@@ -25,20 +25,21 @@ import com.pingcap.tikv.expression.scalar.LessThan;
 import com.pingcap.tikv.expression.scalar.NullEqual;
 
 public class SelectivityCalculator {
-  public static final double SELECTION_FACTOR = 0.8;
-  public static final double EQUAL_RATE = 1000;
-  public static final double LESS_RATE = 3;
+  public static final double SELECTION_FACTOR = 100;
+  public static final double EQUAL_RATE = 0.01;
+  public static final double LESS_RATE = 0.1;
 
   public static double calcPseudoSelectivity(Iterable<TiExpr> exprs) {
     double minFactor = SELECTION_FACTOR;
     for (TiExpr expr : exprs) {
       if (expr instanceof Equal || expr instanceof NullEqual) {
-        minFactor = Math.min(minFactor, 1.0 / EQUAL_RATE);
-      } else if (expr instanceof GreaterEqual ||
+        minFactor *= EQUAL_RATE;
+      } else if (
+          expr instanceof GreaterEqual ||
           expr instanceof GreaterThan ||
           expr instanceof LessEqual ||
           expr instanceof LessThan) {
-        minFactor = Math.min(minFactor, 1.0 / LESS_RATE);
+        minFactor *= LESS_RATE;
       }
     }
     return minFactor;

--- a/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -122,6 +122,7 @@ public class RegionManager {
       for (TiRegion r : regionCache.asMap().values()) {
         if(r.getLeader().getStoreId() == storeId) {
           regionCache.invalidate(r.getId());
+          keyToRegionIdCache.remove(makeRange(r.getStartKey(), r.getEndKey()));
         }
       }
     }
@@ -162,6 +163,9 @@ public class RegionManager {
 
   public Pair<TiRegion, Store> getRegionStorePairByKey(ByteString key) {
     TiRegion region = cache.getRegionByKey(key);
+    if (region == null) {
+      throw new TiClientInternalException("Region not exist for key:" + key);
+    }
     if (!region.isValid()) {
       throw new TiClientInternalException("Region invalid: " + region.toString());
     }

--- a/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -28,6 +28,7 @@ import com.pingcap.tikv.ReadOnlyPDClient;
 import com.pingcap.tikv.TiSession;
 import com.pingcap.tikv.exception.GrpcException;
 import com.pingcap.tikv.exception.TiClientInternalException;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.kvproto.Metapb.Peer;
 import com.pingcap.tikv.kvproto.Metapb.Region;
@@ -191,7 +192,7 @@ public class RegionManager {
   public void onRegionStale(long regionID, List<Region> regions) {
     cache.invalidateRegion(regionID);
     for (Region r : regions) {
-      cache.putRegion(new TiRegion(r, r.getPeers(0), IsolationLevel.RC));
+      cache.putRegion(new TiRegion(r, r.getPeers(0), IsolationLevel.RC, CommandPri.Low));
     }
   }
 

--- a/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -32,6 +32,7 @@ import com.pingcap.tikv.exception.SelectException;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.kvproto.Coprocessor;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
+import com.pingcap.tikv.kvproto.Coprocessor.Response;
 import com.pingcap.tikv.kvproto.Kvrpcpb.BatchGetRequest;
 import com.pingcap.tikv.kvproto.Kvrpcpb.BatchGetResponse;
 import com.pingcap.tikv.kvproto.Kvrpcpb.Context;
@@ -51,9 +52,11 @@ import com.pingcap.tikv.kvproto.TikvGrpc;
 import com.pingcap.tikv.kvproto.TikvGrpc.TikvBlockingStub;
 import com.pingcap.tikv.kvproto.TikvGrpc.TikvStub;
 import com.pingcap.tikv.operation.KVErrorHandler;
+import com.pingcap.tikv.util.FutureObserver;
 import com.pingcap.tikv.util.Pair;
 import io.grpc.ManagedChannel;
 import java.util.List;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 // RegionStore itself is not thread-safe
@@ -183,6 +186,23 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
             regionManager, this, region, resp -> resp.hasRegionError() ? resp.getRegionError() : null);
     Coprocessor.Response resp = callWithRetry(TikvGrpc.METHOD_COPROCESSOR, reqToSend, handler);
     return coprocessorHelper(resp);
+  }
+
+  public Future<SelectResponse> coprocessAsync(SelectRequest req, List<KeyRange> ranges) {
+    FutureObserver<SelectResponse, Response> responseObserver = new FutureObserver<>(this::coprocessorHelper);
+    Supplier<Coprocessor.Request> reqToSend = () ->
+        Coprocessor.Request.newBuilder()
+            .setContext(region.getContext())
+            .setTp(req.hasIndexInfo() ? ReqTypeIndex : ReqTypeSelect)
+            .setData(req.toByteString())
+            .addAllRanges(ranges)
+            .build();
+    KVErrorHandler<Coprocessor.Response> handler =
+        new KVErrorHandler<>(
+            regionManager, this, region, resp -> resp.hasRegionError() ? resp.getRegionError() : null);
+
+    callAsyncWithRetry(TikvGrpc.METHOD_COPROCESSOR, reqToSend, responseObserver, handler);
+    return responseObserver.getFuture();
   }
 
   private SelectResponse coprocessorHelper(Coprocessor.Response resp) {

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -37,8 +37,9 @@ public class TiRegion implements Serializable {
   private final Set<Long> unreachableStores;
   private Peer peer;
   private final IsolationLevel isolationLevel;
+  private final Kvrpcpb.CommandPri commandPri;
 
-  public TiRegion(Region meta, Peer peer, IsolationLevel isolationLevel) {
+  public TiRegion(Region meta, Peer peer, IsolationLevel isolationLevel, Kvrpcpb.CommandPri commandPri) {
     Objects.requireNonNull(meta, "meta is null");
     this.meta = decodeRegion(meta);
     if (peer == null || peer.getId() == 0) {
@@ -51,6 +52,7 @@ public class TiRegion implements Serializable {
     }
     this.unreachableStores = new HashSet<>();
     this.isolationLevel = isolationLevel;
+    this.commandPri = commandPri;
   }
 
   private Region decodeRegion(Region region) {

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -98,6 +98,7 @@ public class TiRegion implements Serializable {
   public Kvrpcpb.Context getContext() {
     Kvrpcpb.Context.Builder builder = Kvrpcpb.Context.newBuilder();
     builder.setIsolationLevel(this.isolationLevel);
+    builder.setPriority(this.commandPri);
     builder.setRegionId(meta.getId()).setPeer(this.peer).setRegionEpoch(this.meta.getRegionEpoch());
     return builder.build();
   }

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -41,6 +41,7 @@ public class TiRegion implements Serializable {
 
   public TiRegion(Region meta, Peer peer, IsolationLevel isolationLevel, Kvrpcpb.CommandPri commandPri) {
     Objects.requireNonNull(meta, "meta is null");
+    // we need decode this region since it gets from pd.
     this.meta = decodeRegion(meta);
     if (peer == null || peer.getId() == 0) {
       if (meta.getPeersCount() == 0) {

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -26,6 +26,7 @@ import com.pingcap.tikv.kvproto.Metapb;
 import com.pingcap.tikv.kvproto.Metapb.Peer;
 import com.pingcap.tikv.kvproto.Metapb.Region;
 import com.pingcap.tikv.types.BytesType;
+
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
@@ -41,7 +42,6 @@ public class TiRegion implements Serializable {
 
   public TiRegion(Region meta, Peer peer, IsolationLevel isolationLevel, Kvrpcpb.CommandPri commandPri) {
     Objects.requireNonNull(meta, "meta is null");
-    // we need decode this region since it gets from pd.
     this.meta = decodeRegion(meta);
     if (peer == null || peer.getId() == 0) {
       if (meta.getPeersCount() == 0) {

--- a/src/main/java/com/pingcap/tikv/types/BytesType.java
+++ b/src/main/java/com/pingcap/tikv/types/BytesType.java
@@ -66,8 +66,10 @@ public class BytesType extends DataType {
       throw new UnsupportedOperationException("can not cast non String type to String");
     }
     if (encodeType == EncodeType.KEY) {
+      cdo.write(BYTES_FLAG);
       writeBytes(cdo, bytes);
     } else {
+      cdo.write(COMPACT_BYTES_FLAG);
       writeCompactBytes(cdo, bytes);
     }
   }

--- a/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -38,17 +38,17 @@ public abstract class DataType implements Serializable {
 
   // encoding/decoding flag
   private static final int NULL_FLAG = 0;
-  static final int BYTES_FLAG = 1;
-  static final int COMPACT_BYTES_FLAG = 2;
-  static final int INT_FLAG = 3;
-  static final int UINT_FLAG = 4;
-  static final int FLOATING_FLAG = 5;
-  static final int DECIMAL_FLAG = 6;
-  static final int DURATION_FLAG = 7;
-  static final int VARINT_FLAG = 8;
-  static final int UVARINT_FLAG = 9;
-  private static final int JSON_FLAG = 10;
-  private static final int MAX_FLAG = 250;
+  public static final int BYTES_FLAG = 1;
+  public static final int COMPACT_BYTES_FLAG = 2;
+  public static final int INT_FLAG = 3;
+  public static final int UINT_FLAG = 4;
+  public static final int FLOATING_FLAG = 5;
+  public static final int DECIMAL_FLAG = 6;
+  public static final int DURATION_FLAG = 7;
+  public static final int VARINT_FLAG = 8;
+  public static final int UVARINT_FLAG = 9;
+  public static final int JSON_FLAG = 10;
+  public static final int MAX_FLAG = 250;
   // MySQL type
   protected int tp;
   // Not Encode/Decode flag, this is used to strict mysql type
@@ -125,23 +125,31 @@ public abstract class DataType implements Serializable {
     }
   }
 
-  public static void indexMaxValue(CodecDataOutput cdo) {
+  public static void encodeIndexMaxValue(CodecDataOutput cdo) {
     cdo.writeByte(MAX_FLAG);
   }
 
-  public static void indexMinValue(CodecDataOutput cdo) {
+  public static void encodeIndexMinValue(CodecDataOutput cdo) {
     cdo.writeByte(BYTES_FLAG);
   }
 
-  public static ByteString indexMaxValue() {
+  public static int indexMinValueFlag() {
+    return BYTES_FLAG;
+  }
+
+  public static int indexMaxValueFlag() {
+    return MAX_FLAG;
+  }
+
+  public static ByteString encodeIndexMaxValue() {
     CodecDataOutput cdo = new CodecDataOutput();
-    indexMaxValue(cdo);
+    encodeIndexMaxValue(cdo);
     return cdo.toByteString();
   }
 
-  public static ByteString indexMinValue() {
+  public static ByteString encodeIndexMinValue() {
     CodecDataOutput cdo = new CodecDataOutput();
-    indexMinValue(cdo);
+    encodeIndexMinValue(cdo);
     return cdo.toByteString();
   }
 
@@ -151,7 +159,7 @@ public abstract class DataType implements Serializable {
    * @param cdo destination of data.
    */
   public void encodeMaxValue(CodecDataOutput cdo) {
-    indexMaxValue(cdo);
+    encodeIndexMaxValue(cdo);
   }
 
   /**
@@ -160,7 +168,7 @@ public abstract class DataType implements Serializable {
    * @param cdo destination of data.
    */
   public void encodeMinValue(CodecDataOutput cdo) {
-    indexMinValue(cdo);
+    encodeIndexMinValue(cdo);
   }
 
   /**

--- a/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -15,6 +15,17 @@
 
 package com.pingcap.tikv.types;
 
+import static com.pingcap.tikv.types.Types.AutoIncrementFlag;
+import static com.pingcap.tikv.types.Types.MultipleKeyFlag;
+import static com.pingcap.tikv.types.Types.NoDefaultValueFlag;
+import static com.pingcap.tikv.types.Types.NotNullFlag;
+import static com.pingcap.tikv.types.Types.OnUpdateNowFlag;
+import static com.pingcap.tikv.types.Types.PriKeyFlag;
+import static com.pingcap.tikv.types.Types.TimestampFlag;
+import static com.pingcap.tikv.types.Types.UniqueKeyFlag;
+import static com.pingcap.tikv.types.Types.UnsignedFlag;
+import static com.pingcap.tikv.types.Types.ZerofillFlag;
+
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataInput;
@@ -22,11 +33,8 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import com.pingcap.tikv.row.Row;
-
 import java.io.Serializable;
 import java.util.List;
-
-import static com.pingcap.tikv.types.Types.*;
 
 /** Base Type for encoding and decoding TiDB row information. */
 public abstract class DataType implements Serializable {

--- a/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -26,7 +26,7 @@ import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
-import java.util.Date;
+import java.sql.Date;
 
 public class DateType extends DataType {
   static DateType of(int tp) {
@@ -59,10 +59,11 @@ public class DateType extends DataType {
       if (value instanceof Date) {
         in = (Date) value;
       } else {
-        in = format.parse(value.toString());
+        // format ensure only date part without time
+        in = new Date(format.parse(value.toString()).getTime());
       }
     } catch (Exception e) {
-      throw new TiClientInternalException("Can not cast Object to LocalDateTime ", e);
+      throw new TiClientInternalException("Can not cast Object to LocalDateTime: " + value, e);
     }
     long val = toPackedLong(in);
     codecObject.encodeNotNull(cdo, encodeType, val);

--- a/src/main/java/com/pingcap/tikv/types/DateType.java
+++ b/src/main/java/com/pingcap/tikv/types/DateType.java
@@ -22,16 +22,18 @@ import static com.pingcap.tikv.types.TimestampType.toPackedLong;
 
 import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.codec.CodecDataOutput;
-import com.pingcap.tikv.codec.InvalidCodecFormatException;
+import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.meta.TiColumnInfo;
-import java.sql.Date;
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.util.Date;
 
 public class DateType extends DataType {
   static DateType of(int tp) {
     return new DateType(tp);
   }
+  private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+  private static final IntegerType codecObject = IntegerType.DEF_LONG_LONG_TYPE;
 
   private DateType(int tp) {
     super(tp);
@@ -39,32 +41,31 @@ public class DateType extends DataType {
 
   @Override
   public Object decodeNotNull(int flag, CodecDataInput cdi) {
-    if (flag == UVARINT_FLAG) {
-      // read packedUint
-      LocalDateTime localDateTime = fromPackedLong(IntegerType.readUVarLong(cdi));
-      if (localDateTime == null) {
-        return null;
-      }
-      //TODO revisit this later.
-      return new Date(localDateTime.getYear() - 1900,
-                            localDateTime.getMonthValue() - 1,
-                            localDateTime.getDayOfMonth());
-    } else {
-      throw new InvalidCodecFormatException("Invalid Flag type for DateType: " + flag);
+    long val = IntegerType.decodeNotNullPrimitive(flag, cdi);
+    LocalDateTime localDateTime = fromPackedLong(val);
+    if (localDateTime == null) {
+      return null;
     }
+    //TODO revisit this later.
+    return new Date(localDateTime.getYear() - 1900,
+        localDateTime.getMonthValue() - 1,
+        localDateTime.getDayOfMonth());
   }
 
   @Override
   public void encodeNotNull(CodecDataOutput cdo, EncodeType encodeType, Object value) {
     Date in;
-    // TODO, is LocalDateTime enough here?
-    if (value instanceof Date) {
-      in = (Date) value;
-    } else {
-      throw new UnsupportedOperationException("Can not cast Object to LocalDateTime ");
+    try {
+      if (value instanceof Date) {
+        in = (Date) value;
+      } else {
+        in = format.parse(value.toString());
+      }
+    } catch (Exception e) {
+      throw new TiClientInternalException("Can not cast Object to LocalDateTime ", e);
     }
-    long val = toPackedLong(LocalDateTime.of(in.toLocalDate(), LocalTime.of(0, 0, 0)));
-    IntegerType.writeULong(cdo, val);
+    long val = toPackedLong(in);
+    codecObject.encodeNotNull(cdo, encodeType, val);
   }
 
   DateType(TiColumnInfo.InternalTypeHolder holder) {

--- a/src/main/java/com/pingcap/tikv/types/IntegerType.java
+++ b/src/main/java/com/pingcap/tikv/types/IntegerType.java
@@ -228,6 +228,10 @@ public class IntegerType extends DataType {
     return TableCodec.flipSignBit(cdi.readLong());
   }
 
+  public static long readPartialLong(CodecDataInput cdi) {
+    return TableCodec.flipSignBit(cdi.readPartialLong());
+  }
+
   /**
    * Decode as unsigned long without any binary manipulation
    *

--- a/src/main/java/com/pingcap/tikv/types/IntegerType.java
+++ b/src/main/java/com/pingcap/tikv/types/IntegerType.java
@@ -28,6 +28,8 @@ import com.pingcap.tikv.meta.TiColumnInfo;
 
 /** Base class for all integer types: Tiny, Short, Medium, Int, Long and LongLong */
 public class IntegerType extends DataType {
+  public static final IntegerType DEF_LONG_TYPE = new IntegerType(Types.TYPE_LONG);
+  public static final IntegerType DEF_LONG_LONG_TYPE = new IntegerType(Types.TYPE_LONG_LONG);
 
   static IntegerType of(int tp) {
     return new IntegerType(tp);
@@ -39,6 +41,10 @@ public class IntegerType extends DataType {
 
   @Override
   public Object decodeNotNull(int flag, CodecDataInput cdi) {
+    return decodeNotNullPrimitive(flag, cdi);
+  }
+
+  public static long decodeNotNullPrimitive(int flag, CodecDataInput cdi) {
     switch (flag) {
       case UVARINT_FLAG:
         return readUVarLong(cdi);
@@ -49,7 +55,7 @@ public class IntegerType extends DataType {
       case INT_FLAG:
         return readLong(cdi);
       default:
-        throw new TiClientInternalException("Invalid " + toString() + " flag: " + flag);
+        throw new TiClientInternalException("Invalid IntegerType flag: " + flag);
     }
   }
 

--- a/src/main/java/com/pingcap/tikv/util/FastByteComparisons.java
+++ b/src/main/java/com/pingcap/tikv/util/FastByteComparisons.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pingcap.tikv.util;
+
+import java.lang.reflect.Field;
+import java.nio.ByteOrder;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import sun.misc.Unsafe;
+
+import com.google.common.primitives.Longs;
+import com.google.common.primitives.UnsignedBytes;
+
+/**
+ * Utility code to do optimized byte-array comparison.
+ * This is borrowed from Apache Cassandra which was borrowed from Guava in turn...
+ */
+public abstract class FastByteComparisons {
+
+  /**
+   * Lexicographically compare two byte arrays.
+   */
+  public static int compareTo(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+    return LexicographicalComparerHolder.BEST_COMPARER.compareTo(
+        b1, s1, l1, b2, s2, l2);
+  }
+
+  private interface Comparer<T> {
+    abstract public int compareTo(T buffer1, int offset1, int length1,
+        T buffer2, int offset2, int length2);
+  }
+
+  private static Comparer<byte[]> lexicographicalComparerJavaImpl() {
+    return LexicographicalComparerHolder.PureJavaComparer.INSTANCE;
+  }
+
+
+  /**
+   * Provides a lexicographical comparer implementation; either a Java
+   * implementation or a faster implementation based on {@link Unsafe}.
+   *
+   * <p>Uses reflection to gracefully fall back to the Java implementation if
+   * {@code Unsafe} isn't available.
+   */
+  private static class LexicographicalComparerHolder {
+    static final String UNSAFE_COMPARER_NAME =
+        LexicographicalComparerHolder.class.getName() + "$UnsafeComparer";
+
+    static final Comparer<byte[]> BEST_COMPARER = getBestComparer();
+    /**
+     * Returns the Unsafe-using Comparer, or falls back to the pure-Java
+     * implementation if unable to do so.
+     */
+    static Comparer<byte[]> getBestComparer() {
+      try {
+        Class<?> theClass = Class.forName(UNSAFE_COMPARER_NAME);
+
+        // yes, UnsafeComparer does implement Comparer<byte[]>
+        @SuppressWarnings("unchecked")
+        Comparer<byte[]> comparer =
+            (Comparer<byte[]>) theClass.getEnumConstants()[0];
+        return comparer;
+      } catch (Throwable t) { // ensure we really catch *everything*
+        return lexicographicalComparerJavaImpl();
+      }
+    }
+
+    private enum PureJavaComparer implements Comparer<byte[]> {
+      INSTANCE;
+
+      @Override
+      public int compareTo(byte[] buffer1, int offset1, int length1,
+          byte[] buffer2, int offset2, int length2) {
+        // Short circuit equal case
+        if (buffer1 == buffer2 &&
+            offset1 == offset2 &&
+            length1 == length2) {
+          return 0;
+        }
+        int end1 = offset1 + length1;
+        int end2 = offset2 + length2;
+        for (int i = offset1, j = offset2; i < end1 && j < end2; i++, j++) {
+          int a = (buffer1[i] & 0xff);
+          int b = (buffer2[j] & 0xff);
+          if (a != b) {
+            return a - b;
+          }
+        }
+        return length1 - length2;
+      }
+    }
+
+    @SuppressWarnings("unused") // used via reflection
+    private enum UnsafeComparer implements Comparer<byte[]> {
+      INSTANCE;
+
+      static final Unsafe theUnsafe;
+
+      /** The offset to the first element in a byte array. */
+      static final int BYTE_ARRAY_BASE_OFFSET;
+
+      static {
+        theUnsafe = (Unsafe) AccessController.doPrivileged(
+            new PrivilegedAction<Object>() {
+              @Override
+              public Object run() {
+                try {
+                  Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                  f.setAccessible(true);
+                  return f.get(null);
+                } catch (NoSuchFieldException e) {
+                  // It doesn't matter what we throw;
+                  // it's swallowed in getBestComparer().
+                  throw new Error();
+                } catch (IllegalAccessException e) {
+                  throw new Error();
+                }
+              }
+            });
+
+        BYTE_ARRAY_BASE_OFFSET = theUnsafe.arrayBaseOffset(byte[].class);
+
+        // sanity check - this should never fail
+        if (theUnsafe.arrayIndexScale(byte[].class) != 1) {
+          throw new AssertionError();
+        }
+      }
+
+      static final boolean littleEndian =
+          ByteOrder.nativeOrder().equals(ByteOrder.LITTLE_ENDIAN);
+
+      /**
+       * Returns true if x1 is less than x2, when both values are treated as
+       * unsigned.
+       */
+      static boolean lessThanUnsigned(long x1, long x2) {
+        return (x1 + Long.MIN_VALUE) < (x2 + Long.MIN_VALUE);
+      }
+
+      /**
+       * Lexicographically compare two arrays.
+       *
+       * @param buffer1 left operand
+       * @param buffer2 right operand
+       * @param offset1 Where to start comparing in the left buffer
+       * @param offset2 Where to start comparing in the right buffer
+       * @param length1 How much to compare from the left buffer
+       * @param length2 How much to compare from the right buffer
+       * @return 0 if equal, < 0 if left is less than right, etc.
+       */
+      @Override
+      public int compareTo(byte[] buffer1, int offset1, int length1,
+          byte[] buffer2, int offset2, int length2) {
+        // Short circuit equal case
+        if (buffer1 == buffer2 &&
+            offset1 == offset2 &&
+            length1 == length2) {
+          return 0;
+        }
+        int minLength = Math.min(length1, length2);
+        int minWords = minLength / Longs.BYTES;
+        int offset1Adj = offset1 + BYTE_ARRAY_BASE_OFFSET;
+        int offset2Adj = offset2 + BYTE_ARRAY_BASE_OFFSET;
+
+        /*
+         * Compare 8 bytes at a time. Benchmarking shows comparing 8 bytes at a
+         * time is no slower than comparing 4 bytes at a time even on 32-bit.
+         * On the other hand, it is substantially faster on 64-bit.
+         */
+        for (int i = 0; i < minWords * Longs.BYTES; i += Longs.BYTES) {
+          long lw = theUnsafe.getLong(buffer1, offset1Adj + (long) i);
+          long rw = theUnsafe.getLong(buffer2, offset2Adj + (long) i);
+          long diff = lw ^ rw;
+
+          if (diff != 0) {
+            if (!littleEndian) {
+              return lessThanUnsigned(lw, rw) ? -1 : 1;
+            }
+
+            // Use binary search
+            int n = 0;
+            int y;
+            int x = (int) diff;
+            if (x == 0) {
+              x = (int) (diff >>> 32);
+              n = 32;
+            }
+
+            y = x << 16;
+            if (y == 0) {
+              n += 16;
+            } else {
+              x = y;
+            }
+
+            y = x << 8;
+            if (y == 0) {
+              n += 8;
+            }
+            return (int) (((lw >>> n) & 0xFFL) - ((rw >>> n) & 0xFFL));
+          }
+        }
+
+        // The epilogue to cover the last (minLength % 8) elements.
+        for (int i = minWords * Longs.BYTES; i < minLength; i++) {
+          int result = UnsignedBytes.compare(
+              buffer1[offset1 + i],
+              buffer2[offset2 + i]);
+          if (result != 0) {
+            return result;
+          }
+        }
+        return length1 - length2;
+      }
+    }
+  }
+}

--- a/src/main/java/com/pingcap/tikv/util/FastByteComparisons.java
+++ b/src/main/java/com/pingcap/tikv/util/FastByteComparisons.java
@@ -29,7 +29,7 @@ import com.google.common.primitives.UnsignedBytes;
 
 /**
  * Utility code to do optimized byte-array comparison.
- * This is borrowed from Apache Cassandra which was borrowed from Guava in turn...
+ * This is borrowed from Apache Cassandra which was borrowed from Guava in turn with minor change
  */
 public abstract class FastByteComparisons {
 
@@ -39,6 +39,11 @@ public abstract class FastByteComparisons {
   public static int compareTo(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
     return LexicographicalComparerHolder.BEST_COMPARER.compareTo(
         b1, s1, l1, b2, s2, l2);
+  }
+
+  public static int compareTo(byte[] b1, byte[] b2) {
+    return LexicographicalComparerHolder.BEST_COMPARER.compareTo(
+        b1, 0, b1.length, b2, 0, b2.length);
   }
 
   private interface Comparer<T> {

--- a/src/main/java/com/pingcap/tikv/util/FastByteComparisons.java
+++ b/src/main/java/com/pingcap/tikv/util/FastByteComparisons.java
@@ -17,15 +17,14 @@
  */
 package com.pingcap.tikv.util;
 
+import com.google.common.primitives.Longs;
+import com.google.common.primitives.UnsignedBytes;
+import sun.misc.Unsafe;
+
 import java.lang.reflect.Field;
 import java.nio.ByteOrder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-
-import sun.misc.Unsafe;
-
-import com.google.common.primitives.Longs;
-import com.google.common.primitives.UnsignedBytes;
 
 /**
  * Utility code to do optimized byte-array comparison.
@@ -47,7 +46,7 @@ public abstract class FastByteComparisons {
   }
 
   private interface Comparer<T> {
-    abstract public int compareTo(T buffer1, int offset1, int length1,
+    int compareTo(T buffer1, int offset1, int length1,
         T buffer2, int offset2, int length2);
   }
 

--- a/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -43,15 +43,21 @@ public class KeyRangeUtils {
   }
 
   public static String toString(Coprocessor.KeyRange range) {
-    return String.format("[%s, %s]",
+    return String.format("Start:[%s], End: [%s]",
         TableCodec.decodeRowKey(range.getStart()),
         TableCodec.decodeRowKey(range.getEnd()));
   }
 
   public static String toString(Coprocessor.KeyRange range, List<DataType> types) {
-    return String.format("[%s, %s]",
-        TableCodec.decodeIndexSeekKeyToString(range.getStart(), types),
-        TableCodec.decodeIndexSeekKeyToString(range.getEnd(), types));
+    if (range == null || types == null) {
+      return "";
+    }
+    try {
+      return String.format("{[%s], [%s]}",
+          TableCodec.decodeIndexSeekKeyToString(range.getStart(), types),
+          TableCodec.decodeIndexSeekKeyToString(range.getEnd(), types));
+    } catch (Exception ignore) {}
+    return range.toString();
   }
 
   public static List<DataType> getIndexColumnTypes(TiTableInfo table, TiIndexInfo index) {

--- a/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -29,6 +29,7 @@ import com.pingcap.tikv.meta.TiIndexColumn;
 import com.pingcap.tikv.meta.TiIndexInfo;
 import com.pingcap.tikv.meta.TiTableInfo;
 import com.pingcap.tikv.types.DataType;
+
 import java.util.List;
 
 public class KeyRangeUtils {
@@ -46,7 +47,7 @@ public class KeyRangeUtils {
   }
 
   public static List<Coprocessor.KeyRange> split(Coprocessor.KeyRange range, int splitFactor) {
-    if (splitFactor > 16 || splitFactor <= 0 || (splitFactor & (splitFactor - 1)) != 0) {
+    if (splitFactor > 32 || splitFactor <= 0 || (splitFactor & (splitFactor - 1)) != 0) {
       throw new TiClientInternalException(
           "splitFactor must be positive integer power of 2 and no greater than 16");
     }
@@ -58,20 +59,17 @@ public class KeyRangeUtils {
       return ImmutableList.of(range);
     }
 
-    int maxSize = Math.max(startKey.size(), endKey.size());
     ImmutableList.Builder<Coprocessor.KeyRange> resultList = ImmutableList.builder();
-    int i;
+    int minSize = Math.min(startKey.size(), endKey.size());
 
-    for (i = 0; i < maxSize; i++) {
-      byte sb = i < startKey.size() ? startKey.byteAt(i) : 0;
-      byte eb = i < endKey.size() ? endKey.byteAt(i) : 0;
-      if (sb != eb) {
+    for (int i = 0; i < minSize; i ++) {
+      if (startKey.byteAt(i) != endKey.byteAt(i)) {
         break;
       }
     }
 
-    ByteString sRemaining = i < startKey.size() ? startKey.substring(i) : ByteString.EMPTY;
-    ByteString eRemaining = i < endKey.size() ? endKey.substring(i) : ByteString.EMPTY;
+    ByteString sRemaining = startKey.substring(minSize);
+    ByteString eRemaining = endKey.substring(minSize);
 
     CodecDataInput cdi = new CodecDataInput(sRemaining);
     int uss = cdi.readPartialUnsignedShort();
@@ -84,8 +82,7 @@ public class KeyRangeUtils {
       return ImmutableList.of(range);
     }
 
-    ByteString prefix = startKey.size() > endKey.size() ?
-                        startKey.substring(0, i) : endKey.substring(0, i);
+    ByteString prefix = startKey.substring(0, minSize);
     ByteString newStartKey = startKey;
     ByteString newEndKey;
     for (int j = 0; j < splitFactor; j++) {
@@ -143,17 +140,17 @@ public class KeyRangeUtils {
     return Range.closedOpen(Comparables.wrap(startKey), Comparables.wrap(endKey));
   }
 
-  public static Coprocessor.KeyRange makeCoprocRange(ByteString startKey, ByteString endKey) {
+  static Coprocessor.KeyRange makeCoprocRange(ByteString startKey, ByteString endKey) {
     return KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build();
   }
 
-  public static Coprocessor.KeyRange makeCoprocRangeWithHandle(long tableId, long startHandle, long endHandle) {
+  static Coprocessor.KeyRange makeCoprocRangeWithHandle(long tableId, long startHandle, long endHandle) {
     ByteString startKey = TableCodec.encodeRowKeyWithHandle(tableId, startHandle);
     ByteString endKey = TableCodec.encodeRowKeyWithHandle(tableId, endHandle);
     return KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build();
   }
 
-  public static String formatByteString(ByteString key) {
+  static String formatByteString(ByteString key) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < key.size(); i++) {
       sb.append(key.byteAt(i) & 0xff);

--- a/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -17,7 +17,9 @@ package com.pingcap.tikv.util;
 
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
+import com.pingcap.tikv.codec.TableCodec;
 import com.pingcap.tikv.kvproto.Coprocessor;
+import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 
 public class KeyRangeUtils {
   public static Range toRange(Coprocessor.KeyRange range) {
@@ -37,7 +39,6 @@ public class KeyRangeUtils {
     if (startKey.isEmpty() && endKey.isEmpty()) {
       return Range.all();
     }
-    Range<? extends Comparable> result = Range.all();
     if (startKey.isEmpty()) {
       return Range.lessThan(Comparables.wrap(endKey));
     } else if (endKey.isEmpty()) {
@@ -46,7 +47,13 @@ public class KeyRangeUtils {
     return Range.closedOpen(Comparables.wrap(startKey), Comparables.wrap(endKey));
   }
 
-  static String formatByteString(ByteString key) {
+  public static Coprocessor.KeyRange makeCoprocRangeWithHandle(long tableId, long startHandle, long endHandle) {
+    ByteString startKey = TableCodec.encodeRowKeyWithHandle(tableId, startHandle);
+    ByteString endKey = TableCodec.encodeRowKeyWithHandle(tableId, endHandle);
+    return KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build();
+  }
+
+  public static String formatByteString(ByteString key) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < key.size(); i++) {
       sb.append(key.byteAt(i) & 0xff);

--- a/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -50,8 +50,8 @@ public class KeyRangeUtils {
 
   public static String toString(Coprocessor.KeyRange range, List<DataType> types) {
     return String.format("[%s, %s]",
-        TableCodec.decodeIndexSeekKey(range.getStart(), types),
-        TableCodec.decodeIndexSeekKey(range.getEnd(), types));
+        TableCodec.decodeIndexSeekKeyToString(range.getStart(), types),
+        TableCodec.decodeIndexSeekKeyToString(range.getEnd(), types));
   }
 
   public static List<DataType> getIndexColumnTypes(TiTableInfo table, TiIndexInfo index) {

--- a/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -18,7 +18,10 @@ package com.pingcap.tikv.util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.protobuf.ByteString;
+import com.pingcap.tikv.codec.CodecDataInput;
+import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.codec.TableCodec;
+import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.kvproto.Coprocessor;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 import com.pingcap.tikv.meta.TiColumnInfo;
@@ -40,6 +43,65 @@ public class KeyRangeUtils {
       return Range.atLeast(Comparables.wrap(range.getStart()));
     }
     return Range.closedOpen(Comparables.wrap(range.getStart()), Comparables.wrap(range.getEnd()));
+  }
+
+  public static List<Coprocessor.KeyRange> split(Coprocessor.KeyRange range, int splitFactor) {
+    if (splitFactor > 16 || splitFactor <= 0 || (splitFactor & (splitFactor - 1)) != 0) {
+      throw new TiClientInternalException(
+          "splitFactor must be positive integer power of 2 and no greater than 16");
+    }
+
+    ByteString startKey = range.getStart();
+    ByteString endKey = range.getEnd();
+    // we don't cut infinite
+    if (startKey.isEmpty() || endKey.isEmpty()) {
+      return ImmutableList.of(range);
+    }
+
+    int maxSize = Math.max(startKey.size(), endKey.size());
+    ImmutableList.Builder<Coprocessor.KeyRange> resultList = ImmutableList.builder();
+    int i;
+
+    for (i = 0; i < maxSize; i++) {
+      byte sb = i < startKey.size() ? startKey.byteAt(i) : 0;
+      byte eb = i < endKey.size() ? endKey.byteAt(i) : 0;
+      if (sb != eb) {
+        break;
+      }
+    }
+
+    ByteString sRemaining = i < startKey.size() ? startKey.substring(i) : ByteString.EMPTY;
+    ByteString eRemaining = i < endKey.size() ? endKey.substring(i) : ByteString.EMPTY;
+
+    CodecDataInput cdi = new CodecDataInput(sRemaining);
+    int uss = cdi.readPartialUnsignedShort();
+
+    cdi = new CodecDataInput(eRemaining);
+    int ues = cdi.readPartialUnsignedShort();
+
+    int delta = (ues - uss) / splitFactor;
+    if (delta <= 0) {
+      return ImmutableList.of(range);
+    }
+
+    ByteString prefix = startKey.size() > endKey.size() ?
+                        startKey.substring(0, i) : endKey.substring(0, i);
+    ByteString newStartKey = startKey;
+    ByteString newEndKey;
+    for (int j = 0; j < splitFactor; j++) {
+      uss += delta;
+      if (j == splitFactor - 1) {
+        newEndKey = endKey;
+      } else {
+        CodecDataOutput cdo = new CodecDataOutput();
+        cdo.writeShort(uss);
+        newEndKey = prefix.concat(cdo.toByteString());
+      }
+      resultList.add(makeCoprocRange(newStartKey, newEndKey));
+      newStartKey = newEndKey;
+    }
+
+    return resultList.build();
   }
 
   public static String toString(Coprocessor.KeyRange range) {
@@ -79,6 +141,10 @@ public class KeyRangeUtils {
       return Range.atLeast(Comparables.wrap(startKey));
     }
     return Range.closedOpen(Comparables.wrap(startKey), Comparables.wrap(endKey));
+  }
+
+  public static Coprocessor.KeyRange makeCoprocRange(ByteString startKey, ByteString endKey) {
+    return KeyRange.newBuilder().setStart(startKey).setEnd(endKey).build();
   }
 
   public static Coprocessor.KeyRange makeCoprocRangeWithHandle(long tableId, long startHandle, long endHandle) {

--- a/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
+++ b/src/main/java/com/pingcap/tikv/util/KeyRangeUtils.java
@@ -60,16 +60,19 @@ public class KeyRangeUtils {
     }
 
     ImmutableList.Builder<Coprocessor.KeyRange> resultList = ImmutableList.builder();
-    int minSize = Math.min(startKey.size(), endKey.size());
+    int maxSize = Math.max(startKey.size(), endKey.size());
+    int i;
 
-    for (int i = 0; i < minSize; i ++) {
-      if (startKey.byteAt(i) != endKey.byteAt(i)) {
+    for (i = 0; i < maxSize; i++) {
+      byte sb = i < startKey.size() ? startKey.byteAt(i) : 0;
+      byte eb = i < endKey.size() ? endKey.byteAt(i) : 0;
+      if (sb != eb) {
         break;
       }
     }
 
-    ByteString sRemaining = startKey.substring(minSize);
-    ByteString eRemaining = endKey.substring(minSize);
+    ByteString sRemaining = i < startKey.size() ? startKey.substring(i) : ByteString.EMPTY;
+    ByteString eRemaining = i < endKey.size() ? endKey.substring(i) : ByteString.EMPTY;
 
     CodecDataInput cdi = new CodecDataInput(sRemaining);
     int uss = cdi.readPartialUnsignedShort();
@@ -82,7 +85,8 @@ public class KeyRangeUtils {
       return ImmutableList.of(range);
     }
 
-    ByteString prefix = startKey.substring(0, minSize);
+    ByteString prefix = startKey.size() > endKey.size() ?
+                        startKey.substring(0, i) : endKey.substring(0, i);
     ByteString newStartKey = startKey;
     ByteString newEndKey;
     for (int j = 0; j < splitFactor; j++) {

--- a/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -189,8 +189,6 @@ public class RangeSplitter {
     regionTasks.add(new RegionTask(regionStorePair.first, regionStorePair.second, newKeyRanges));
   }
 
-
-
   public List<RegionTask> splitRangeByRegion(List<KeyRange> keyRanges) {
     if (keyRanges == null || keyRanges.size() == 0) {
       return ImmutableList.of();

--- a/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -196,26 +196,8 @@ public class RangeSplitter {
         endHandle = startHandle;
       }
     }
-
-    ByteString startKeyBS = TableCodec.encodeRowKeyWithHandle(tableId, startHandle);
-    ByteString endKeyBS;
-    ByteString regionEndKey = region.getEndKey();
-
-    byte[] endKey = TableCodec.encodeRowKeyWithHandleBytes(tableId, endHandle + 1);
-    if (!regionEndKey.isEmpty() && FastByteComparisons.compareTo(endKey, regionEndKey.toByteArray()) > 0) {
-      endKeyBS = region.getEndKey();
-    } else {
-      endKeyBS = ByteString.copyFrom(endKey);
-    }
-
-    newKeyRanges.add(KeyRange
-        .newBuilder()
-        .setStart(startKeyBS)
-        .setEnd(endKeyBS)
-        .build()
-    );
-
-    regionTasks.add(new RegionTask(region, store, newKeyRanges));
+    newKeyRanges.add(KeyRangeUtils.makeCoprocRangeWithHandle(tableId, startHandle, endHandle + 1));
+    regionTasks.add(new RegionTask(regionStorePair.first, regionStorePair.second, newKeyRanges));
   }
 
   public List<RegionTask> splitRangeByRegion(List<KeyRange> keyRanges) {

--- a/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -15,7 +15,6 @@
 
 package com.pingcap.tikv.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.pingcap.tikv.util.KeyRangeUtils.formatByteString;
 import static java.util.Objects.requireNonNull;
 
@@ -27,7 +26,10 @@ import com.pingcap.tikv.kvproto.Metapb;
 import com.pingcap.tikv.region.RegionManager;
 import com.pingcap.tikv.region.TiRegion;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class RangeSplitter {
   public static class RegionTask implements Serializable {
@@ -114,7 +116,10 @@ public class RangeSplitter {
   }
 
   public List<RegionTask> splitRangeByRegion(List<KeyRange> keyRanges) {
-    checkArgument(keyRanges != null && keyRanges.size() != 0);
+    if (keyRanges == null || keyRanges.size() == 0) {
+      return ImmutableList.of();
+    }
+
     int i = 0;
     KeyRange range = keyRanges.get(i++);
     Map<Long, List<KeyRange>> idToRange = new HashMap<>(); // region id to keyRange list

--- a/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -134,7 +134,7 @@ public class RangeSplitter {
       TableCodec.tryDecodeRowKey(tableId, endKey, decodeResult);
       if (decodeResult.status == Status.MIN) {
         throw new TiClientInternalException("EndKey is less than current rowKey");
-      } else if (decodeResult.status == Status.MAX) {
+      } else if (decodeResult.status == Status.MAX || decodeResult.status == Status.UNKNOWN_INF) {
         createTask(startPos, handles.size(), tableId, handles, regionStorePair, regionTasks);
         break;
       }
@@ -186,8 +186,7 @@ public class RangeSplitter {
       }
     }
     newKeyRanges.add(KeyRangeUtils.makeCoprocRangeWithHandle(tableId, startHandle, endHandle + 1));
-    regionTasks.add(
-        new RegionTask(regionStorePair.first, regionStorePair.second, newKeyRanges));
+    regionTasks.add(new RegionTask(regionStorePair.first, regionStorePair.second, newKeyRanges));
   }
 
 

--- a/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -15,9 +15,6 @@
 
 package com.pingcap.tikv.util;
 
-import static com.pingcap.tikv.util.KeyRangeUtils.formatByteString;
-import static java.util.Objects.requireNonNull;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import com.google.protobuf.ByteString;
@@ -30,11 +27,15 @@ import com.pingcap.tikv.kvproto.Metapb.Store;
 import com.pingcap.tikv.region.RegionManager;
 import com.pingcap.tikv.region.TiRegion;
 import gnu.trove.list.array.TLongArrayList;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static com.pingcap.tikv.util.KeyRangeUtils.formatByteString;
+import static java.util.Objects.requireNonNull;
 
 public class RangeSplitter {
   public static class RegionTask implements Serializable {
@@ -186,7 +187,6 @@ public class RangeSplitter {
       long curHandle = handles.get(i);
       if (endHandle + 1 == curHandle) {
         endHandle = curHandle;
-        continue;
       } else {
         newKeyRanges.add(KeyRangeUtils.makeCoprocRangeWithHandle(
             tableId,

--- a/src/main/java/com/pingcap/tikv/util/Timer.java
+++ b/src/main/java/com/pingcap/tikv/util/Timer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.util;
+
+import java.util.concurrent.TimeUnit;
+
+final public class Timer {
+  private long startTime;
+
+  public Timer() {
+    reset();
+  }
+
+  public long stop(TimeUnit tu) {
+    return tu.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+  }
+
+  public void reset() {
+    startTime = System.nanoTime();
+  }
+}

--- a/src/test/java/com/pingcap/tikv/RegionStoreClientTest.java
+++ b/src/test/java/com/pingcap/tikv/RegionStoreClientTest.java
@@ -26,6 +26,7 @@ import com.pingcap.tidb.tipb.SelectRequest;
 import com.pingcap.tidb.tipb.SelectResponse;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
 import com.pingcap.tikv.kvproto.Kvrpcpb;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.kvproto.Metapb;
 import com.pingcap.tikv.region.RegionStoreClient;
@@ -67,7 +68,7 @@ public class RegionStoreClientTest {
             .addPeers(Metapb.Peer.newBuilder().setId(11).setStoreId(13))
             .build();
 
-    region = new TiRegion(r, r.getPeers(0), IsolationLevel.RC);
+    region = new TiRegion(r, r.getPeers(0), IsolationLevel.RC, CommandPri.Low);
     server = new KVMockServer();
     port = server.start(region);
     // No PD needed in this test

--- a/src/test/java/com/pingcap/tikv/catalog/CatalogTest.java
+++ b/src/test/java/com/pingcap/tikv/catalog/CatalogTest.java
@@ -7,6 +7,8 @@ import com.pingcap.tikv.KVMockServer;
 import com.pingcap.tikv.PDMockServer;
 import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.kvproto.Kvrpcpb;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.meta.MetaUtils.MetaMockHelper;
 import com.pingcap.tikv.meta.TiDBInfo;
@@ -30,7 +32,8 @@ public class CatalogTest {
     pdServer = new PDMockServer();
     pdServer.start(CLUSTER_ID);
     kvServer = new KVMockServer();
-    kvServer.start(new TiRegion(MetaMockHelper.region, MetaMockHelper.region.getPeers(0), IsolationLevel.RC));
+    kvServer.start(new TiRegion(MetaMockHelper.region, MetaMockHelper.region.getPeers(0), IsolationLevel.RC,
+        CommandPri.Low));
     // No PD needed in this test
     conf = TiConfiguration.createDefault("127.0.0.1:" + pdServer.port);
   }

--- a/src/test/java/com/pingcap/tikv/catalog/CatalogTransactionTest.java
+++ b/src/test/java/com/pingcap/tikv/catalog/CatalogTransactionTest.java
@@ -21,6 +21,7 @@ import com.pingcap.tikv.KVMockServer;
 import com.pingcap.tikv.PDMockServer;
 import com.pingcap.tikv.TiConfiguration;
 import com.pingcap.tikv.TiSession;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.meta.MetaUtils.MetaMockHelper;
 import com.pingcap.tikv.meta.TiDBInfo;
@@ -42,7 +43,8 @@ public class CatalogTransactionTest {
     pdServer = new PDMockServer();
     pdServer.start(CLUSTER_ID);
     kvServer = new KVMockServer();
-    kvServer.start(new TiRegion(MetaMockHelper.region, MetaMockHelper.region.getPeers(0), IsolationLevel.RC));
+    kvServer.start(new TiRegion(MetaMockHelper.region, MetaMockHelper.region.getPeers(0),
+        IsolationLevel.RC, CommandPri.Low));
     // No PD needed in this test
     conf = TiConfiguration.createDefault("127.0.0.1:" + pdServer.port);
   }

--- a/src/test/java/com/pingcap/tikv/meta/TiSelectRequestTest.java
+++ b/src/test/java/com/pingcap/tikv/meta/TiSelectRequestTest.java
@@ -56,8 +56,8 @@ public class TiSelectRequestTest {
     TiTableInfo table = createTable();
     TiSelectRequest selReq = new TiSelectRequest();
     selReq
-        .addField(TiColumnRef.create("c1", table))
-        .addField(TiColumnRef.create("c2", table))
+        .addRequiredColumn(TiColumnRef.create("c1", table))
+        .addRequiredColumn(TiColumnRef.create("c2", table))
         .addAggregate(new Sum(TiColumnRef.create("c1", table)))
         .addAggregate(new Min(TiColumnRef.create("c1", table)))
         .addWhere(new Plus(TiConstant.create(1L), TiConstant.create(2L)))

--- a/src/test/java/com/pingcap/tikv/operation/ChunkIteratorTest.java
+++ b/src/test/java/com/pingcap/tikv/operation/ChunkIteratorTest.java
@@ -52,7 +52,7 @@ public class ChunkIteratorTest {
 
   @Test
   public void chunkTest() {
-    ChunkIterator chunkIterator = new ChunkIterator(chunks, false);
+    ChunkIterator<ByteString> chunkIterator = ChunkIterator.getRawBytesChunkIterator(chunks);
     DataType bytes = DataTypeFactory.of(TYPE_VARCHAR);
     DataType ints = DataTypeFactory.of(TYPE_LONG);
     Row row = ObjectRowImpl.create(6);

--- a/src/test/java/com/pingcap/tikv/operation/ChunkIteratorTest.java
+++ b/src/test/java/com/pingcap/tikv/operation/ChunkIteratorTest.java
@@ -49,9 +49,10 @@ public class ChunkIteratorTest {
         .build();
     chunks.add(chunk);
   }
+
   @Test
   public void chunkTest() {
-    ChunkIterator chunkIterator = new ChunkIterator(chunks);
+    ChunkIterator chunkIterator = new ChunkIterator(chunks, false);
     DataType bytes = DataTypeFactory.of(TYPE_VARCHAR);
     DataType ints = DataTypeFactory.of(TYPE_LONG);
     Row row = ObjectRowImpl.create(6);

--- a/src/test/java/com/pingcap/tikv/predicates/RangeBuilderTest.java
+++ b/src/test/java/com/pingcap/tikv/predicates/RangeBuilderTest.java
@@ -15,8 +15,6 @@
 
 package com.pingcap.tikv.predicates;
 
-import static org.junit.Assert.*;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
@@ -29,8 +27,12 @@ import com.pingcap.tikv.meta.TiTableInfo;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.DataTypeFactory;
 import com.pingcap.tikv.types.Types;
-import java.util.List;
 import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RangeBuilderTest {
   private static TiTableInfo createTable() {
@@ -126,7 +128,7 @@ public class RangeBuilderTest {
             );
     DataType type = DataTypeFactory.of(Types.TYPE_LONG);
     RangeBuilder builder = new RangeBuilder();
-    List<Range> ranges = builder.exprToRanges(conds, type);
+    List<Range> ranges = RangeBuilder.exprToRanges(conds, type);
     assertEquals(2, ranges.size());
     assertEquals(Range.closedOpen(0L, 50L), ranges.get(0));
     assertEquals(Range.open(50L, 100L), ranges.get(1));
@@ -153,7 +155,7 @@ public class RangeBuilderTest {
             new NotEqual(TiColumnRef.create("c3", table), TiConstant.create("g")) // c1 != 50
             );
     type = DataTypeFactory.of(Types.TYPE_STRING);
-    ranges = builder.exprToRanges(conds, type);
+    ranges = RangeBuilder.exprToRanges(conds, type);
 
     indexRanges = RangeBuilder.appendRanges(indexRanges, ranges, type);
     assertEquals(4, indexRanges.size());

--- a/src/test/java/com/pingcap/tikv/types/TimestampTest.java
+++ b/src/test/java/com/pingcap/tikv/types/TimestampTest.java
@@ -17,15 +17,20 @@
 
 package com.pingcap.tikv.types;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import org.junit.Test;
 
 public class TimestampTest {
   @Test
-  public void fromPackedLongAndToPackedLongTest() {
+  public void fromPackedLongAndToPackedLongTest() throws ParseException {
 
     LocalDateTime time = LocalDateTime.of(1999, 12, 12, 1, 1, 1, 1000);
     LocalDateTime time1 = TimestampType.fromPackedLong(TimestampType.toPackedLong(time));
@@ -56,5 +61,11 @@ public class TimestampTest {
     LocalDateTime time9 = LocalDateTime.parse("2017-01-05 23:59:59:5756010", formatter);
     LocalDateTime time10 = TimestampType.fromPackedLong(TimestampType.toPackedLong(time9));
     assertEquals(time9, time10);
+
+    SimpleDateFormat formatter1 = new SimpleDateFormat("yyyy-MM-dd");
+    Date date1 = formatter1.parse("2099-10-30");
+    long time11 = TimestampType.toPackedLong(date1);
+    LocalDateTime time12 = TimestampType.fromPackedLong(time11);
+    assertEquals(time12.toLocalDate(), new java.sql.Date(date1.getTime()).toLocalDate());
   }
 }

--- a/src/test/java/com/pingcap/tikv/util/KeyRangeUtilsTest.java
+++ b/src/test/java/com/pingcap/tikv/util/KeyRangeUtilsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pingcap.tikv.util;
+
+import static com.pingcap.tikv.util.KeyRangeUtils.makeCoprocRange;
+import static org.junit.Assert.assertEquals;
+
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
+import java.util.List;
+import org.junit.Test;
+
+public class KeyRangeUtilsTest {
+
+  @Test
+  public void split() throws Exception {
+    ByteString s = ByteString.copyFrom(new byte[] {1,2,3,5});
+    ByteString e = ByteString.copyFrom(new byte[] {1,2,3,8});
+    List<KeyRange> result = KeyRangeUtils.split(makeCoprocRange(s, e), 2);
+
+    assertEquals(2, result.size());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,6, (byte)128}), result.get(0).getEnd());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,6, (byte)128}), result.get(1).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,8}), result.get(1).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3,5});
+    e = ByteString.copyFrom(new byte[] {1,2,3,6});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+
+    assertEquals(4, result.size());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5, (byte)64}), result.get(0).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5, (byte)64}), result.get(1).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5, (byte)128}), result.get(1).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5, (byte)128}), result.get(2).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5, (byte)192}), result.get(2).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5, (byte)192}), result.get(3).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,6}), result.get(3).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3,5});
+    e = ByteString.copyFrom(new byte[] {1,2,3,5});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(1, result.size());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(0).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3});
+    e = ByteString.copyFrom(new byte[] {1,2,3,5});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(4, result.size());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,1, (byte)64}), result.get(0).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,1, (byte)64}), result.get(1).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,2, (byte)128}), result.get(1).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,2, (byte)128}), result.get(2).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,3, (byte)192}), result.get(2).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,3, (byte)192}), result.get(3).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(3).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3,0});
+    e = ByteString.copyFrom(new byte[] {1,2,3});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(1, result.size());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3}), result.get(0).getEnd());
+
+    s = ByteString.EMPTY;
+    e = ByteString.copyFrom(new byte[] {1,2,3});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(1, result.size());
+
+    assertEquals(ByteString.EMPTY, result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3}), result.get(0).getEnd());
+
+
+    s = ByteString.copyFrom(new byte[] {1,2,3});
+    e = ByteString.copyFrom(new byte[] {1,2,3,0,0,0});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(1, result.size());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0}), result.get(0).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3});
+    e = ByteString.copyFrom(new byte[] {1,2,3,1,-128,1});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(4, result.size());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,96}), result.get(0).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,96}), result.get(1).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,(byte)192}), result.get(1).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,(byte)192}), result.get(2).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,1,(byte)32}), result.get(2).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,1,(byte)32}), result.get(3).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,1,(byte)128,1}), result.get(3).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3});
+    e = ByteString.copyFrom(new byte[] {1,2,3,0,0,1});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(4, result.size());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,64}), result.get(0).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,64}), result.get(1).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,(byte)128}), result.get(1).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,(byte)128}), result.get(2).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,(byte)192}), result.get(2).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,(byte)192}), result.get(3).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,1}), result.get(3).getEnd());
+  }
+
+}

--- a/src/test/java/com/pingcap/tikv/util/KeyRangeUtilsTest.java
+++ b/src/test/java/com/pingcap/tikv/util/KeyRangeUtilsTest.java
@@ -15,13 +15,14 @@
 
 package com.pingcap.tikv.util;
 
-import static com.pingcap.tikv.util.KeyRangeUtils.makeCoprocRange;
-import static org.junit.Assert.assertEquals;
-
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
-import java.util.List;
 import org.junit.Test;
+
+import java.util.List;
+
+import static com.pingcap.tikv.util.KeyRangeUtils.makeCoprocRange;
+import static org.junit.Assert.assertEquals;
 
 public class KeyRangeUtilsTest {
 
@@ -135,6 +136,30 @@ public class KeyRangeUtilsTest {
 
     assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,0,(byte)192}), result.get(3).getStart());
     assertEquals(ByteString.copyFrom(new byte[] {1,2,3,0,0,1}), result.get(3).getEnd());
+
+    /** for now only larger diff will be counted*/
+    s = ByteString.copyFrom(new byte[] {1,2,3,4,(byte)255});
+    e = ByteString.copyFrom(new byte[] {1,2,3,5});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 1);
+    assertEquals(1, result.size());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,4,(byte)255}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(0).getEnd());
+
+    s = ByteString.copyFrom(new byte[] {1,2,3,5});
+    e = ByteString.copyFrom(new byte[] {1,2,4,5});
+    result = KeyRangeUtils.split(makeCoprocRange(s, e), 4);
+    assertEquals(4, result.size());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,5}), result.get(0).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,(byte)69}), result.get(0).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,(byte)69}), result.get(1).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,(byte)133}), result.get(1).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,(byte)133}), result.get(2).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,(byte)197}), result.get(2).getEnd());
+
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,3,(byte)197}), result.get(3).getStart());
+    assertEquals(ByteString.copyFrom(new byte[] {1,2,4,5}), result.get(3).getEnd());
   }
 
 }

--- a/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -9,6 +9,7 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.codec.TableCodec;
 import com.pingcap.tikv.codec.TableCodec.DecodeResult.Status;
 import com.pingcap.tikv.kvproto.Coprocessor.KeyRange;
+import com.pingcap.tikv.kvproto.Kvrpcpb.CommandPri;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.kvproto.Metapb;
 import com.pingcap.tikv.kvproto.Metapb.Peer;
@@ -110,7 +111,7 @@ public class RangeSplitterTest {
             .setEndKey(encodeKey(range.getEnd().toByteArray()))
             .addPeers(Peer.getDefaultInstance())
             .build(),
-        null, IsolationLevel.RC);
+        null, IsolationLevel.RC, CommandPri.Low);
   }
 
   @Test

--- a/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -165,29 +165,26 @@ public class RangeSplitterTest {
     assertEquals(tasks.get(0).getRanges().get(0), keyRangeByHandle(tableId, Long.MIN_VALUE, Long.MIN_VALUE + 1));
     assertEquals(tasks.get(0).getRanges().get(1), keyRangeByHandle(tableId, -255L, -254L));
 
-    // [-100, 10.x): [-100, -97), [-1, 0), [1, 6), [10, 10.x)
-    ByteString regionEndKey = tasks.get(1).getRegion().getEndKey();
+    // [-100, 10.x): [-100, -97), [-1, 0), [1, 6), [10, 11)
     assertEquals(tasks.get(1).getRegion().getId(), 1);
     assertEquals(tasks.get(1).getRanges().size(), 4);
     assertEquals(tasks.get(1).getRanges().get(0), keyRangeByHandle(tableId, -100L, -97L));
     assertEquals(tasks.get(1).getRanges().get(1), keyRangeByHandle(tableId, -1L, 0L));
     assertEquals(tasks.get(1).getRanges().get(2), keyRangeByHandle(tableId, 1L, 6L));
-    assertEquals(tasks.get(1).getRanges().get(3), keyRangeByHandle(tableId, 10L, regionEndKey));
+    assertEquals(tasks.get(1).getRanges().get(3), keyRangeByHandle(tableId, 10L, 11L));
 
     // [10.x, 50): empty
-    // [50, 100.x): [88, 89) [99, 100.x)
-    regionEndKey = tasks.get(2).getRegion().getEndKey();
+    // [50, 100.x): [88, 89) [99, 101)
     assertEquals(tasks.get(2).getRegion().getId(), 3);
     assertEquals(tasks.get(2).getRanges().size(), 2);
     assertEquals(tasks.get(2).getRanges().get(0), keyRangeByHandle(tableId, 88L, 89L));
-    assertEquals(tasks.get(2).getRanges().get(1), keyRangeByHandle(tableId, 99L, regionEndKey));
+    assertEquals(tasks.get(2).getRanges().get(1), keyRangeByHandle(tableId, 99L, 101L));
 
-    // [100.x, less than 8960): [101, 102) [8959, regionEndKey)
-    regionEndKey = tasks.get(3).getRegion().getEndKey();
+    // [100.x, less than 8960): [101, 102) [8959, 8960)
     assertEquals(tasks.get(3).getRegion().getId(), 4);
     assertEquals(tasks.get(3).getRanges().size(), 2);
     assertEquals(tasks.get(3).getRanges().get(0), keyRangeByHandle(tableId, 101L, 102L));
-    assertEquals(tasks.get(3).getRanges().get(1), keyRangeByHandle(tableId, 8959L, regionEndKey));
+    assertEquals(tasks.get(3).getRanges().get(1), keyRangeByHandle(tableId, 8959L, 8960L));
 
     // [less than 8960, 16000): [9000, 9001), [15001, 15002)
     assertEquals(tasks.get(4).getRegion().getId(), 5);

--- a/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -71,8 +71,9 @@ public class RangeSplitterTest {
         return v.substring(0, v.size() - 1);
       case GREATER:
         return v.concat(ByteString.copyFrom(new byte[] {1, 0}));
+      default:
+    	throw new IllegalArgumentException("Only EQUAL,LESS,GREATER allowed");
     }
-    throw new IllegalArgumentException("Only EQUAL,LESS,GREATER allowed");
   }
 
   private static KeyRange keyRangeByHandle(long tableId, Long s, Status ss, Long e, Status es) {


### PR DESCRIPTION
Original done by @zhexuany but out of date too far. Redo it again on latest code and fixes on the fly (some of plan logic were not fully tested due to no downstream logic).

1. Optimize handle to keyrange process
2. Added concurrency beside Spark's split.
3. Allow further split region into smaller parts for speed
4. Index selection upon pseudo logic before histogram merge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/114)
<!-- Reviewable:end -->
