### PR TITLE
fix decode Region in TiRegion

### DIFF
--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -18,14 +18,12 @@
 package com.pingcap.tikv.region;
 
 import com.google.protobuf.ByteString;
-import com.pingcap.tikv.codec.CodecDataInput;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.kvproto.Kvrpcpb;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
 import com.pingcap.tikv.kvproto.Metapb;
 import com.pingcap.tikv.kvproto.Metapb.Peer;
 import com.pingcap.tikv.kvproto.Metapb.Region;
-import com.pingcap.tikv.types.BytesType;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -40,7 +40,7 @@ public class TiRegion implements Serializable {
 
   public TiRegion(Region meta, Peer peer, IsolationLevel isolationLevel) {
     Objects.requireNonNull(meta, "meta is null");
-    this.meta = decodeRegion(meta);
+    this.meta = meta;
     if (peer == null || peer.getId() == 0) {
       if (meta.getPeersCount() == 0) {
         throw new TiClientInternalException("Empty peer list for region " + meta.getId());
@@ -51,30 +51,6 @@ public class TiRegion implements Serializable {
     }
     this.unreachableStores = new HashSet<>();
     this.isolationLevel = isolationLevel;
-  }
-
-  private Region decodeRegion(Region region) {
-    Region.Builder builder =
-        Region.newBuilder()
-            .setId(region.getId())
-            .setRegionEpoch(region.getRegionEpoch())
-            .addAllPeers(region.getPeersList());
-
-    if (region.getStartKey().isEmpty()) {
-      builder.setStartKey(region.getStartKey());
-    } else {
-      byte[] decodecStartKey = BytesType.readBytes(new CodecDataInput(region.getStartKey()));
-      builder.setStartKey(ByteString.copyFrom(decodecStartKey));
-    }
-
-    if (region.getEndKey().isEmpty()) {
-      builder.setEndKey(region.getEndKey());
-    } else {
-      byte[] decodecEndKey = BytesType.readBytes(new CodecDataInput(region.getEndKey()));
-      builder.setEndKey(ByteString.copyFrom(decodecEndKey));
-    }
-
-    return builder.build();
   }
 
   public Peer getLeader() {

--- a/src/test/java/com/pingcap/tikv/PDClientTest.java
+++ b/src/test/java/com/pingcap/tikv/PDClientTest.java
@@ -92,8 +92,8 @@ public class PDClientTest {
             server.getClusterId(),
             GrpcUtils.makeRegion(
                 1,
-                encodeKey(startKey),
-                encodeKey(endKey),
+                ByteString.copyFrom(startKey),
+                ByteString.copyFrom(endKey),
                 GrpcUtils.makeRegionEpoch(confVer, ver),
                 GrpcUtils.makePeer(1, 10),
                 GrpcUtils.makePeer(2, 20))));
@@ -119,8 +119,8 @@ public class PDClientTest {
             server.getClusterId(),
             GrpcUtils.makeRegion(
                 1,
-                encodeKey(startKey),
-                encodeKey(endKey),
+                ByteString.copyFrom(startKey),
+                ByteString.copyFrom(endKey),
                 GrpcUtils.makeRegionEpoch(confVer, ver),
                 GrpcUtils.makePeer(1, 10),
                 GrpcUtils.makePeer(2, 20))));
@@ -147,8 +147,8 @@ public class PDClientTest {
             server.getClusterId(),
             GrpcUtils.makeRegion(
                 1,
-                encodeKey(startKey),
-                encodeKey(endKey),
+                ByteString.copyFrom(startKey),
+                ByteString.copyFrom(endKey),
                 GrpcUtils.makeRegionEpoch(confVer, ver),
                 GrpcUtils.makePeer(1, 10),
                 GrpcUtils.makePeer(2, 20))));
@@ -174,8 +174,8 @@ public class PDClientTest {
             server.getClusterId(),
             GrpcUtils.makeRegion(
                 1,
-                encodeKey(startKey),
-                encodeKey(endKey),
+                ByteString.copyFrom(startKey),
+                ByteString.copyFrom(endKey),
                 GrpcUtils.makeRegionEpoch(confVer, ver),
                 GrpcUtils.makePeer(1, 10),
                 GrpcUtils.makePeer(2, 20))));

--- a/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
+++ b/src/test/java/com/pingcap/tikv/util/RangeSplitterTest.java
@@ -66,8 +66,8 @@ public class RangeSplitterTest {
     return new TiRegion(
         Metapb.Region.newBuilder()
             .setId(id)
-            .setStartKey(encodeKey(range.getStart().toByteArray()))
-            .setEndKey(encodeKey(range.getEnd().toByteArray()))
+            .setStartKey(ByteString.copyFrom(range.getStart().toByteArray()))
+            .setEndKey(ByteString.copyFrom(range.getEnd().toByteArray()))
             .addPeers(Peer.getDefaultInstance())
             .build(),
         null, IsolationLevel.RC);


### PR DESCRIPTION
We encode key in test case, as a result we have to decode key in TiRegion in order to pass test case. It is a mistake and will be corrected in this PR. 

@ilovesoup @birdstorm PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/116)
<!-- Reviewable:end -->
