### PR TITLE
[Bug fix]Fix Flen overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Since it's not quite complete, a usage sample for now can be given is:
         TiTableInfo table = cat.getTable(db, "t2");
 
 ....
-
         Snapshot snapshot = session.createSnapshot();
         Iterator<Row> it = snapshot.newSelect(table)
                 .addRange(TiRange.create(0L, Long.MAX_VALUE))

--- a/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -104,7 +104,7 @@ public class TiColumnInfo implements Serializable {
   public static class InternalTypeHolder {
     private final int tp;
     private final int flag;
-    private final int flen;
+    private final long flen;
     private final int decimal;
     private final String charset;
     private final String collate;
@@ -118,7 +118,7 @@ public class TiColumnInfo implements Serializable {
     public InternalTypeHolder(
         @JsonProperty("Tp") int tp,
         @JsonProperty("Flag") int flag,
-        @JsonProperty("Flen") int flen,
+        @JsonProperty("Flen") long flen,
         @JsonProperty("Decimal") int decimal,
         @JsonProperty("Charset") String charset,
         @JsonProperty("Collate") String collate,
@@ -150,7 +150,7 @@ public class TiColumnInfo implements Serializable {
       return flag;
     }
 
-    public int getFlen() {
+    public long getFlen() {
       return flen;
     }
 
@@ -184,10 +184,9 @@ public class TiColumnInfo implements Serializable {
         .setColumnId(id)
         .setTp(type.getTypeCode())
         .setCollation(type.getCollationCode())
-        .setColumnLen(type.getLength())
+        .setColumnLen((int) type.getLength())
         .setDecimal(type.getDecimal())
         .setFlag(type.getFlag())
-        .setColumnLen(type.getLength())
         .setPkHandle(table.isPkHandle() && isPrimaryKey())
         .addAllElems(type.getElems());
   }

--- a/src/main/java/com/pingcap/tikv/meta/TiIndexColumn.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiIndexColumn.java
@@ -23,13 +23,13 @@ import java.io.Serializable;
 public class TiIndexColumn implements Serializable {
   private String name;
   private int offset;
-  private int length;
+  private long length;
 
   @JsonCreator
   TiIndexColumn(
       @JsonProperty("name") CIStr name,
       @JsonProperty("offset") int offset,
-      @JsonProperty("length") int length) {
+      @JsonProperty("length") long length) {
     this.name = name.getL();
     this.offset = offset;
     this.length = length;
@@ -43,7 +43,7 @@ public class TiIndexColumn implements Serializable {
     return offset;
   }
 
-  public int getLength() {
+  public long getLength() {
     return length;
   }
 

--- a/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -15,8 +15,6 @@
 
 package com.pingcap.tikv.types;
 
-import static com.pingcap.tikv.types.Types.*;
-
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataInput;
@@ -24,8 +22,11 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import com.pingcap.tikv.row.Row;
+
 import java.io.Serializable;
 import java.util.List;
+
+import static com.pingcap.tikv.types.Types.*;
 
 /** Base Type for encoding and decoding TiDB row information. */
 public abstract class DataType implements Serializable {
@@ -56,7 +57,7 @@ public abstract class DataType implements Serializable {
   protected int flag;
   protected int decimal;
   protected int collation;
-  protected int length;
+  protected long length;
   private List<String> elems;
 
   protected DataType(TiColumnInfo.InternalTypeHolder holder) {
@@ -184,7 +185,7 @@ public abstract class DataType implements Serializable {
     return collation;
   }
 
-  public int getLength() {
+  public long getLength() {
     return length;
   }
 
@@ -277,12 +278,12 @@ public abstract class DataType implements Serializable {
 
   @Override
   public int hashCode() {
-    return 31
-        * (tp == 0 ? 1 : tp)
-        * (flag == 0 ? 1 : flag)
-        * (decimal == 0 ? 1 : decimal)
-        * (collation == 0 ? 1 : collation)
-        * (length == 0 ? 1 : length)
-        * (elems.hashCode());
+    return (int) (31
+            * (tp == 0 ? 1 : tp)
+            * (flag == 0 ? 1 : flag)
+            * (decimal == 0 ? 1 : decimal)
+            * (collation == 0 ? 1 : collation)
+            * (length == 0 ? 1 : length)
+            * (elems.hashCode()));
   }
 }


### PR DESCRIPTION
In some cases, field length may exceed ```Integer.MAX_INT```, so we need to us ```Long``` to store it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/122)
<!-- Reviewable:end -->
