### PR TITLE
Fix therad-pool not exit properly issue

### DIFF
--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -34,7 +34,7 @@ public class Main {
     }
     //testUniqueIndex();
     //tableScan();
-//    indexScan();
+    indexScan();
     session.close();
   }
 

--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -15,6 +15,7 @@ import com.pingcap.tikv.predicates.PredicateUtils;
 import com.pingcap.tikv.predicates.ScanBuilder;
 import com.pingcap.tikv.row.Row;
 import com.pingcap.tikv.util.Timer;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -33,9 +34,8 @@ public class Main {
     }
     //testUniqueIndex();
     //tableScan();
-    indexScan();
+//    indexScan();
     session.close();
-    System.exit(0);
   }
 
   private static void testUniqueIndex() {
@@ -77,7 +77,7 @@ public class Main {
       for (int i = 0; i < r.fieldCount(); i++) {
         Object v = r.get(i, schemaInfer.getType(i));
         if (v != null)
-          acc += (Long)v;
+          acc += (Long) v;
       }
     }
     System.out.println("acc:" + acc);
@@ -121,7 +121,7 @@ public class Main {
       for (int i = 0; i < r.fieldCount(); i++) {
         Object v = r.get(i, schemaInfer.getType(i));
         if (v instanceof Long)
-          acc += (Long)v;
+          acc += (Long) v;
       }
     }
     System.out.println("acc:" + acc);
@@ -167,7 +167,7 @@ public class Main {
       for (int i = 0; i < r.fieldCount(); i++) {
         Object v = r.get(i, schemaInfer.getType(i));
         if (v != null)
-          acc += (Long)v;
+          acc += (Long) v;
       }
     }
     System.out.println("acc:" + acc);

--- a/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/src/main/java/com/pingcap/tikv/TiSession.java
@@ -21,7 +21,7 @@ import com.pingcap.tikv.catalog.Catalog;
 import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.region.RegionManager;
 import io.grpc.ManagedChannel;
-import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.ManagedChannelBuilder;
 import io.netty.channel.EventLoopGroup;
 
 import java.util.ArrayList;
@@ -118,7 +118,7 @@ public class TiSession implements AutoCloseable {
 
       // Channel should be lazy without actual connection until first call
       // So a coarse grain lock is ok here
-      channel = NettyChannelBuilder.forAddress(address.getHostText(), address.getPort())
+      channel = ManagedChannelBuilder.forAddress(address.getHostText(), address.getPort())
           .maxInboundMessageSize(conf.getMaxFrameSize())
           .usePlaintext(true)
           .idleTimeout(60, TimeUnit.SECONDS)

--- a/src/main/java/com/pingcap/tikv/TiSession.java
+++ b/src/main/java/com/pingcap/tikv/TiSession.java
@@ -22,11 +22,8 @@ import com.pingcap.tikv.meta.TiTimestamp;
 import com.pingcap.tikv.region.RegionManager;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.netty.channel.EventLoopGroup;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,8 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 
 public class TiSession implements AutoCloseable {
-  public static final Map<String, ManagedChannel> connPool = new HashMap<>();
-  public static List<Thread> threadList = new ArrayList<>();
+  private static final Map<String, ManagedChannel> connPool = new HashMap<>();
   private final TiConfiguration conf;
   // below object creation is either heavy or making connection (pd), pending for lazy loading
   private volatile RegionManager regionManager;
@@ -43,7 +39,6 @@ public class TiSession implements AutoCloseable {
   private volatile Catalog catalog;
   private volatile ExecutorService indexScanThreadPool;
   private volatile ExecutorService tableScanThreadPool;
-  public EventLoopGroup eventLoopGroup;
 
   public TiSession(TiConfiguration conf) {
     this.conf = conf;

--- a/src/main/java/com/pingcap/tikv/catalog/Catalog.java
+++ b/src/main/java/com/pingcap/tikv/catalog/Catalog.java
@@ -17,6 +17,7 @@ package com.pingcap.tikv.catalog;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.pingcap.tikv.Snapshot;
 import com.pingcap.tikv.meta.TiDBInfo;
 import com.pingcap.tikv.meta.TiTableInfo;
@@ -25,10 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 public class Catalog implements AutoCloseable {
@@ -113,7 +111,7 @@ public class Catalog implements AutoCloseable {
     this.snapshotProvider = Objects.requireNonNull(snapshotProvider,
                                                    "Snapshot Provider is null");
     metaCache = new CatalogCache(new CatalogTransaction(snapshotProvider.get()));
-    service = Executors.newSingleThreadScheduledExecutor();
+    service = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setDaemon(true).build());
     service.scheduleAtFixedRate(this::reloadCache, refreshPeriod, refreshPeriod, periodUnit);
   }
 


### PR DESCRIPTION
Thread-pools created in `PDClient` and `Catalog` were not set to daemon. Fixed and now we can exit properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/139)
<!-- Reviewable:end -->
