### PR TITLE
fix unsupported expr test

### DIFF
--- a/src/main/java/com/pingcap/tikv/expression/TiExpr.java
+++ b/src/main/java/com/pingcap/tikv/expression/TiExpr.java
@@ -24,7 +24,12 @@ public interface TiExpr extends Serializable {
   Expr toProto();
 
   default boolean isSupportedExpr() {
-    return true;
+    try {
+      Expr expr = toProto();
+      return expr != null;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   DataType getType();


### PR DESCRIPTION
do proto gen check to see if expression is supported. It's a silly but effective test. Consider change it after new DAG framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/144)
<!-- Reviewable:end -->
