### PR TITLE
[Fix]Modify pom to eliminate pb3 affect to master build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,6 @@
                                 <argument>update</argument>
                                 <argument>--init</argument>
                                 <argument>--recursive</argument>
-                                <argument>--remote</argument>
-                                <argument>--merge</argument>
                             </arguments>
                         </configuration>
                         <phase>validate</phase>


### PR DESCRIPTION
Protobuf3 update in protobuf file caused some methods gone, we fix this by pointing the HEAD of proto submodule to a pb2 version and don't let it synchronize with it's master but a fix commit.

Now `mvn clean install` should work in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/153)
<!-- Reviewable:end -->
