### PR TITLE
a trivial fix for distinct and groupby without aggregates before DAG

### DIFF
--- a/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiSelectRequest.java
@@ -32,7 +32,9 @@ import com.pingcap.tikv.util.KeyRangeUtils;
 import com.pingcap.tikv.util.Pair;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TiSelectRequest implements Serializable {
@@ -61,6 +63,7 @@ public class TiSelectRequest implements Serializable {
   // we need a cast to target when given
   private final List<Pair<TiExpr, DataType>> aggregates = new ArrayList<>();
   private final List<KeyRange> keyRanges = new ArrayList<>();
+  private final Set<Integer> skipOrdinal = new HashSet<>();
 
   private int limit;
   private int timeZoneOffset;
@@ -86,6 +89,14 @@ public class TiSelectRequest implements Serializable {
     } else {
       return buildTableScan();
     }
+  }
+
+  public void skipAggregatesAt(int ordinal) {
+    skipOrdinal.add(ordinal);
+  }
+
+  public boolean isAggregatesSkipped(int ordinal) {
+    return skipOrdinal.contains(ordinal);
   }
 
   private SelectRequest buildIndexScan() {

--- a/src/main/java/com/pingcap/tikv/operation/SchemaInfer.java
+++ b/src/main/java/com/pingcap/tikv/operation/SchemaInfer.java
@@ -104,13 +104,7 @@ public class SchemaInfer {
       types.add(DataTypeFactory.of(TYPE_BLOB));
       tiSelectRequest.getAggregates().forEach(expr -> types.add(expr.getType()));
     } else {
-      // skip the only column if no aggregates but group by exists
-      // those cases are distinct and group by without aggregates
-      // and we append fake column for it
-      if (tiSelectRequest.getGroupByItems().isEmpty()) {
-        // Extract all column type information from TiExpr
-        tiSelectRequest.getFields().forEach(expr -> types.add(expr.getType()));
-      }
+      tiSelectRequest.getFields().forEach(expr -> types.add(expr.getType()));
     }
   }
 


### PR DESCRIPTION
For now distinct and group by without aggregates will fail since Coprocessor needs a aggregate function to work when grouping.
Add fake first() in such cases and skip it in schema infer.

Refer to https://github.com/pingcap/tispark/pull/90/files
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/156)
<!-- Reviewable:end -->
