### PR TITLE
Pd cache fix

### DIFF
--- a/src/main/java/com/pingcap/tikv/AbstractGRPCClient.java
+++ b/src/main/java/com/pingcap/tikv/AbstractGRPCClient.java
@@ -30,7 +30,7 @@ import org.apache.log4j.Logger;
 public abstract class AbstractGRPCClient<
         BlockingStubT extends AbstractStub<BlockingStubT>, StubT extends AbstractStub<StubT>>
     implements AutoCloseable {
-  final Logger logger = Logger.getLogger(this.getClass());
+  protected final Logger logger = Logger.getLogger(this.getClass());
   protected TiSession session;
   protected TiConfiguration conf;
 

--- a/src/main/java/com/pingcap/tikv/AbstractGRPCClient.java
+++ b/src/main/java/com/pingcap/tikv/AbstractGRPCClient.java
@@ -51,7 +51,9 @@ public abstract class AbstractGRPCClient<
   protected <ReqT, RespT> RespT callWithRetry(MethodDescriptor<ReqT, RespT> method,
                                               Supplier<ReqT> requestFactory,
                                               ErrorHandler<RespT> handler) {
-    logger.debug(String.format("Calling %s...", method.getFullMethodName()));
+    if (logger.isTraceEnabled()) {
+      logger.trace(String.format("Calling %s...", method.getFullMethodName()));
+    }
     RetryPolicy.Builder<RespT> builder = new Builder<>(conf.getRetryTimes(), conf.getBackOffClass());
     RespT resp =
         builder.create(handler)
@@ -62,7 +64,9 @@ public abstract class AbstractGRPCClient<
                       stub.getChannel(), method, stub.getCallOptions(), requestFactory.get());
                 },
                 method.getFullMethodName());
-    logger.debug(String.format("leaving %s...", method.getFullMethodName()));
+    if (logger.isTraceEnabled()) {
+      logger.trace(String.format("leaving %s...", method.getFullMethodName()));
+    }
     return resp;
   }
 

--- a/src/main/java/com/pingcap/tikv/Main.java
+++ b/src/main/java/com/pingcap/tikv/Main.java
@@ -4,174 +4,65 @@ package com.pingcap.tikv;
 import com.google.common.collect.ImmutableList;
 import com.pingcap.tikv.catalog.Catalog;
 import com.pingcap.tikv.expression.TiColumnRef;
-import com.pingcap.tikv.expression.TiConstant;
-import com.pingcap.tikv.expression.TiExpr;
-import com.pingcap.tikv.expression.scalar.GreaterThan;
+import com.pingcap.tikv.expression.aggregate.Count;
 import com.pingcap.tikv.meta.TiDBInfo;
 import com.pingcap.tikv.meta.TiSelectRequest;
 import com.pingcap.tikv.meta.TiTableInfo;
-import com.pingcap.tikv.operation.SchemaInfer;
-import com.pingcap.tikv.predicates.PredicateUtils;
 import com.pingcap.tikv.predicates.ScanBuilder;
 import com.pingcap.tikv.row.Row;
-import com.pingcap.tikv.util.Timer;
-
+import com.pingcap.tikv.util.RangeSplitter;
+import com.pingcap.tikv.util.RangeSplitter.RegionTask;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import org.apache.log4j.Logger;
 
 public class Main {
-  static TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:" + 2379);
-  static TiSession session = TiSession.create(conf);
-  static Catalog cat = session.getCatalog();
-
+  private static final Logger logger = Logger.getLogger(Main.class);
   public static void main(String[] args) throws Exception {
-    // May need to save this reference
-    if (args.length == 3) {
-      conf.setIndexScanConcurrency(Integer.parseInt(args[0]));
-      conf.setTableScanConcurrency(Integer.parseInt(args[1]));
-      conf.setIndexScanBatchSize(Integer.parseInt(args[2]));
+    TiConfiguration conf = TiConfiguration.createDefault(args[0]);
+    //TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:2379");
+    TiSession session = TiSession.create(conf);
+    Catalog cat = session.getCatalog();
+    int loop = 1000;
+    try {
+      loop = Integer.parseInt(args[3]);
+    } catch (Exception e) {}
+    for (int i = 0; i < loop; i++) {
+      tableScan(cat, session, args[1], args[2]);
+      if (i != loop - 1) {
+        Thread.currentThread().sleep(60000);
+      }
     }
-    //testUniqueIndex();
-    //tableScan();
-    indexScan();
+    //tableScan(cat, session, "test", "test");
+    //System.out.println("2nd round");
+    //tableScan(cat, session, args[1], args[2]);
     session.close();
   }
 
-  private static void testUniqueIndex() {
-    TiDBInfo db = cat.getDatabase("test");
-    TiTableInfo table = cat.getTable(db, "test1");
+  private static void tableScan(Catalog cat, TiSession session, String dbName, String tableName) throws Exception {
+    TiDBInfo db = cat.getDatabase(dbName);
+    TiTableInfo table = cat.getTable(db, tableName);
     Snapshot snapshot = session.createSnapshot();
 
-    System.out.println("Index Scan Start");
-    List<TiExpr> exprs =
-        ImmutableList.of(
-            new GreaterThan(TiColumnRef.create("c3", table),
-                TiConstant.create("aa"))
-        );
+    logger.info(String.format("Table Scan Start: db[%s] table[%s]", dbName, tableName));
 
     ScanBuilder scanBuilder = new ScanBuilder();
-    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildScan(exprs, table);
+    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildTableScan(ImmutableList.of(), table);
 
     TiSelectRequest selReq = new TiSelectRequest();
-    selReq
-        .addRanges(scanPlan.getKeyRanges())
-        .setTableInfo(table)
-        .addRequiredColumn(TiColumnRef.create("c1", table))
-        .addRequiredColumn(TiColumnRef.create("c2", table))
-        .setStartTs(snapshot.getVersion());
+    TiColumnRef firstColumn = TiColumnRef.create(table.getColumns().get(0).getName(), table);
+    selReq.setTableInfo(table)
+          .addAggregate(new Count(firstColumn))
+          .addRequiredColumn(firstColumn)
+          .setStartTs(snapshot.getVersion());
 
-    if (scanPlan.isIndexScan()) {
-      selReq.setIndexInfo(scanPlan.getIndex());
+    List<RegionTask> regionTasks = RangeSplitter
+        .newSplitter(session.getRegionManager())
+        .splitRangeByRegion(scanPlan.getKeyRanges());
+    for (RegionTask task : regionTasks) {
+      Iterator<Row> it = snapshot.tableRead(selReq, ImmutableList.of(task));
+      Row row = it.next();
+      logger.info(String.format("Region:[%s] -> count[%s]", task.getRegion(), row.getLong(1)));
     }
-    System.out.println(scanPlan.getIndex().toString());
-    System.out.println(selReq.toString());
-
-    Timer t1 = new Timer();
-    Iterator<Row> it = snapshot.tableRead(selReq);
-
-    SchemaInfer schemaInfer = SchemaInfer.create(selReq);
-    long acc = 0;
-    while (it.hasNext()) {
-      Row r = it.next();
-      for (int i = 0; i < r.fieldCount(); i++) {
-        Object v = r.get(i, schemaInfer.getType(i));
-        if (v != null)
-          acc += (Long) v;
-      }
-    }
-    System.out.println("acc:" + acc);
-    System.out.println("done t1:" + t1.stop(TimeUnit.SECONDS));
-    System.out.println("");
-  }
-
-  private static void tableScan() throws Exception {
-    TiDBInfo db = cat.getDatabase("TPCH");
-    TiTableInfo table = cat.getTable(db, "lineitem");
-    Snapshot snapshot = session.createSnapshot();
-
-    System.out.println("Table Scan Start");
-    List<TiExpr> exprs =
-        ImmutableList.of(
-            new GreaterThan(TiColumnRef.create("L_SHIPDATE", table),
-                TiConstant.create("1993-07-30"))
-        );
-
-    ScanBuilder scanBuilder = new ScanBuilder();
-    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildTableScan(exprs, table);
-
-    TiSelectRequest selReq = new TiSelectRequest();
-    selReq
-        .addRanges(scanPlan.getKeyRanges())
-        .setTableInfo(table)
-        .addRequiredColumn(TiColumnRef.create("L_LINENUMBER", table))
-        .addRequiredColumn(TiColumnRef.create("L_SHIPDATE", table))
-        .setStartTs(snapshot.getVersion());
-
-    selReq.addWhere(PredicateUtils.mergeCNFExpressions(scanPlan.getFilters()));
-    System.out.println(selReq.toString());
-
-    Timer t1 = new Timer();
-    Iterator<Row> it = snapshot.tableRead(selReq);
-
-    SchemaInfer schemaInfer = SchemaInfer.create(selReq);
-    long acc = 0;
-    while (it.hasNext()) {
-      Row r = it.next();
-      for (int i = 0; i < r.fieldCount(); i++) {
-        Object v = r.get(i, schemaInfer.getType(i));
-        if (v instanceof Long)
-          acc += (Long) v;
-      }
-    }
-    System.out.println("acc:" + acc);
-    System.out.println("done time:" + t1.stop(TimeUnit.SECONDS));
-    System.out.println("");
-  }
-
-  private static void indexScan() throws Exception {
-    TiDBInfo db = cat.getDatabase("TPCH");
-    TiTableInfo table = cat.getTable(db, "lineitem");
-    Snapshot snapshot = session.createSnapshot();
-
-    System.out.println("Index Scan Start");
-    List<TiExpr> exprs =
-        ImmutableList.of(
-            new GreaterThan(TiColumnRef.create("L_SHIPDATE", table),
-                TiConstant.create("1993-07-30"))
-        );
-
-    ScanBuilder scanBuilder = new ScanBuilder();
-    ScanBuilder.ScanPlan scanPlan = scanBuilder.buildScan(exprs, table);
-
-    TiSelectRequest selReq = new TiSelectRequest();
-    selReq
-        .addRanges(scanPlan.getKeyRanges())
-        .setTableInfo(table)
-        .addRequiredColumn(TiColumnRef.create("L_LINENUMBER", table))
-        .setStartTs(snapshot.getVersion());
-
-    if (scanPlan.isIndexScan()) {
-      selReq.setIndexInfo(scanPlan.getIndex());
-    }
-    System.out.println(scanPlan.getIndex().toString());
-    System.out.println(selReq.toString());
-
-    Timer t1 = new Timer();
-    Iterator<Row> it = snapshot.tableRead(selReq);
-
-    SchemaInfer schemaInfer = SchemaInfer.create(selReq);
-    long acc = 0;
-    while (it.hasNext()) {
-      Row r = it.next();
-      for (int i = 0; i < r.fieldCount(); i++) {
-        Object v = r.get(i, schemaInfer.getType(i));
-        if (v != null)
-          acc += (Long) v;
-      }
-    }
-    System.out.println("acc:" + acc);
-    System.out.println("done t1:" + t1.stop(TimeUnit.SECONDS));
-    System.out.println("");
   }
 }

--- a/src/main/java/com/pingcap/tikv/codec/KeyUtils.java
+++ b/src/main/java/com/pingcap/tikv/codec/KeyUtils.java
@@ -30,6 +30,24 @@ public class KeyUtils {
     return Arrays.copyOf(key, key.length + 1);
   }
 
+  public static String formatBytes(byte[] bytes) {
+    if (bytes == null) return "null";
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < bytes.length; i++) {
+      int unsignedByte = UnsignedBytes.toInt(bytes[i]);
+      sb.append(unsignedByte);
+      if (i != bytes.length - 1) {
+        sb.append(",");
+      }
+    }
+    return sb.toString();
+  }
+
+  public static String formatBytes(ByteString bytes) {
+    if (bytes == null) return "null";
+    return formatBytes(bytes.toByteArray());
+  }
+
   /**
    * The next key for bytes domain It first plus one at LSB and if LSB overflows, a zero byte is
    * appended at the end Original bytes will be reused if possible

--- a/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -79,8 +79,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       } else if (error.hasStaleEpoch()) {
         logger.warn(String.format("Stale Epoch encountered for region [%s]", ctxRegion.getId()));
-        this.regionManager.onRegionStale(
-            ctxRegion.getId(), ctxRegion.getLeader(), error.getStaleEpoch().getNewRegionsList());
+        this.regionManager.onRegionStale(ctxRegion.getId());
         throw new GrpcRegionStaleException(error.toString());
       } else if (error.hasServerIsBusy()) {
         logger.warn(String.format("Server is busy for region [%s]", ctxRegion));

--- a/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -97,6 +97,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         logger.warn(String.format("Unknown error for region [%s]", error));
         // for other errors, we only drop cache here and throw a retryable exception.
         regionManager.invalidateRegion(ctxRegion.getId());
+        regionManager.invalidateStore(ctxRegion.getLeader().getStoreId());
         throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       }
     }

--- a/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
+++ b/src/main/java/com/pingcap/tikv/operation/KVErrorHandler.java
@@ -17,6 +17,8 @@
 
 package com.pingcap.tikv.operation;
 
+import com.google.protobuf.ByteString;
+import com.pingcap.tikv.codec.KeyUtils;
 import com.pingcap.tikv.exception.GrpcRegionStaleException;
 import com.pingcap.tikv.kvproto.Errorpb;
 import com.pingcap.tikv.region.RegionErrorReceiver;
@@ -48,6 +50,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
   public void handle(RespT resp) {
     // if resp is null, then region maybe out of dated. we need handle this on RegionManager.
     if (resp == null) {
+      logger.warn(String.format("Request Failed with unknown reason for region region [%s]", ctxRegion));
       regionManager.onRequestFail(ctxRegion.getId(), ctxRegion.getLeader().getStoreId());
       return;
     }
@@ -56,11 +59,8 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
     if (error != null) {
       if (error.hasNotLeader()) {
         // update Leader here
-        logger.warn(String.format("Thread %s: NotLeader Error with region id %d",
-                                  Thread.currentThread().getId(), error.getNotLeader().getRegionId()));
-        logger.warn(String.format("Thread %s: origin call with region id %d and store id %d",
-                                  Thread.currentThread().getId(),
-                                  ctxRegion.getId(),
+        logger.warn(String.format("NotLeader Error with region id %d and store id %d",
+            ctxRegion.getId(),
             ctxRegion.getLeader().getStoreId()));
         long newStoreId = error.getNotLeader().getLeader().getStoreId();
         regionManager.updateLeader(ctxRegion.getId(), newStoreId);
@@ -70,8 +70,8 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       }
       if (error.hasStoreNotMatch()) {
-        logger.warn(String.format("Thread %s: Store Not Match happened with region id %d, store id %d",
-                                  Thread.currentThread().getId(), ctxRegion.getId(),
+        logger.warn(String.format("Store Not Match happened with region id %d, store id %d",
+                                  ctxRegion.getId(),
                                   ctxRegion.getLeader().getStoreId()));
 
         regionManager.invalidateRegion(ctxRegion.getId());
@@ -81,22 +81,33 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
       }
 
       if (error.hasStaleEpoch()) {
+        logger.warn(String.format("Stale Epoch encountered for region [%s]", ctxRegion.getId()));
         this.regionManager.onRegionStale(
             ctxRegion.getId(), ctxRegion.getLeader(), error.getStaleEpoch().getNewRegionsList());
         throw new GrpcRegionStaleException(error.toString());
       }
 
       if (error.hasServerIsBusy()) {
+        logger.warn(String.format("Server is busy for region [%s]", ctxRegion));
         throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       }
 
       if (error.hasStaleCommand()) {
+        logger.warn(String.format("Stale command for region [%s]", ctxRegion));
         throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       }
 
       if (error.hasRaftEntryTooLarge()) {
+        logger.warn(String.format("Raft too large for region [%s]", ctxRegion));
         throw new StatusRuntimeException(Status.fromCode(Status.Code.UNAVAILABLE).withDescription(error.toString()));
       }
+
+      if (error.hasKeyNotInRegion()) {
+        ByteString invalidKey = error.getKeyNotInRegion().getKey();
+        logger.warn(String.format("Key not in region [%s] for key [%s]", ctxRegion, KeyUtils.formatBytes(invalidKey)));
+      }
+
+      logger.warn(String.format("Unknown error for region [%s]", error));
       // for other errors, we only drop cache here and throw a retryable exception.
       regionManager.invalidateRegion(ctxRegion.getId());
     }

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -132,6 +132,9 @@ public abstract class SelectIterator<T, RawT> implements Iterator<T> {
     RegionStoreClient client;
     client = RegionStoreClient.create(region, store, session);
     try {
+      if (logger.isDebugEnabled()) {
+        logger.debug(String.format("RegionTask [%s]", regionTask));
+      }
       SelectResponse resp = client.coprocess(request, ranges);
       // if resp is null, then indicates eof.
       if (resp == null) {

--- a/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
+++ b/src/main/java/com/pingcap/tikv/operation/SelectIterator.java
@@ -41,9 +41,10 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.function.Function;
+import org.apache.log4j.Logger;
 
 public abstract class SelectIterator<T, RawT> implements Iterator<T> {
-
+  private static final Logger logger = Logger.getLogger(SelectIterator.class);
   protected final TiSession session;
   protected final List<RegionTask> regionTasks;
 
@@ -142,6 +143,12 @@ public abstract class SelectIterator<T, RawT> implements Iterator<T> {
       List<Chunk> resultChunk = new ArrayList<>();
       List<RegionTask> splitTasks = RangeSplitter.newSplitter(session.getRegionManager()).splitRangeByRegion(ranges);
       for(RegionTask t : splitTasks) {
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              String.format("createClientAndSendReq split for stale region, old region[%s] - new region[%s]",
+              regionTask.getRegion(),
+              t.getRegion()));
+        }
         List<Chunk> resFromCurTask = createClientAndSendReq(t);
         if(resFromCurTask != null) {
           resultChunk.addAll(resFromCurTask);

--- a/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -36,9 +36,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.log4j.Logger;
 
-import java.util.List;
-
-import static com.pingcap.tikv.util.KeyRangeUtils.makeRange;
 
 public class RegionManager {
   private static final Logger logger = Logger.getLogger(RegionManager.class);

--- a/src/main/java/com/pingcap/tikv/region/RegionManager.java
+++ b/src/main/java/com/pingcap/tikv/region/RegionManager.java
@@ -140,7 +140,7 @@ public class RegionManager {
       }
     }
 
-    public void invalidateStore(long storeId) {
+    public synchronized void invalidateStore(long storeId) {
       storeCache.remove(storeId);
     }
 

--- a/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
+++ b/src/main/java/com/pingcap/tikv/region/RegionStoreClient.java
@@ -55,9 +55,11 @@ import com.pingcap.tikv.util.Pair;
 import io.grpc.ManagedChannel;
 import java.util.List;
 import java.util.function.Supplier;
+import org.apache.log4j.Logger;
 
 // RegionStore itself is not thread-safe
 public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, TikvStub> implements RegionErrorReceiver {
+  private static final Logger logger = Logger.getLogger(RegionStoreClient.class);
   private TiRegion region;
   private TikvBlockingStub blockingStub;
   private TikvStub asyncStub;
@@ -205,6 +207,9 @@ public class RegionStoreClient extends AbstractGRPCClient<TikvBlockingStub, Tikv
       TiRegion region, Store store, TiSession session) {
     RegionStoreClient client;
     String addressStr = store.getAddress();
+    if (logger.isDebugEnabled()) {
+      logger.debug(String.format("Create region store client on address %s", addressStr));
+    }
     ManagedChannel channel = session.getChannel(addressStr);
 
     TikvBlockingStub blockingStub = TikvGrpc.newBlockingStub(channel);

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -148,28 +148,6 @@ public class TiRegion implements Serializable {
     return meta;
   }
 
-  /**
-   * records unreachable peer and tries to select another valid peer. It returns false if all peers
-   * are unreachable.
-   *
-   * @param storeID leader store ID
-   * @return false if peers are unreachable.
-   */
-  boolean onRequestFail(long storeID) {
-    if (this.peer.getStoreId() == storeID) {
-      return true;
-    }
-    this.unreachableStores.add(storeID);
-    for (Peer p : this.meta.getPeersList()) {
-      if (unreachableStores.contains(p.getStoreId())) {
-        continue;
-      }
-      this.peer = p;
-      return true;
-    }
-    return false;
-  }
-
   public String toString() {
     return String.format("{Region[%d] ConfVer[%d] Version[%d] Store[%d] KeyRange[%s]:[%s]}",
                           getId(),

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -19,6 +19,7 @@ package com.pingcap.tikv.region;
 
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataInput;
+import com.pingcap.tikv.codec.KeyUtils;
 import com.pingcap.tikv.exception.TiClientInternalException;
 import com.pingcap.tikv.kvproto.Kvrpcpb;
 import com.pingcap.tikv.kvproto.Kvrpcpb.IsolationLevel;
@@ -167,5 +168,13 @@ public class TiRegion implements Serializable {
       return true;
     }
     return false;
+  }
+
+  public String toString() {
+    return String.format("{Region[%d] Store[%d] KeyRange[%s]:[%s]}",
+                          getId(),
+                          getLeader().getStoreId(),
+                          KeyUtils.formatBytes(getStartKey()),
+                          KeyUtils.formatBytes(getEndKey()));
   }
 }

--- a/src/main/java/com/pingcap/tikv/region/TiRegion.java
+++ b/src/main/java/com/pingcap/tikv/region/TiRegion.java
@@ -171,8 +171,10 @@ public class TiRegion implements Serializable {
   }
 
   public String toString() {
-    return String.format("{Region[%d] Store[%d] KeyRange[%s]:[%s]}",
+    return String.format("{Region[%d] ConfVer[%d] Version[%d] Store[%d] KeyRange[%s]:[%s]}",
                           getId(),
+                          getRegionEpoch().getConfVer(),
+                          getRegionEpoch().getVersion(),
                           getLeader().getStoreId(),
                           KeyUtils.formatBytes(getStartKey()),
                           KeyUtils.formatBytes(getEndKey()));

--- a/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
+++ b/src/main/java/com/pingcap/tikv/util/RangeSplitter.java
@@ -15,6 +15,9 @@
 
 package com.pingcap.tikv.util;
 
+import static com.pingcap.tikv.util.KeyRangeUtils.formatByteString;
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import com.google.protobuf.ByteString;
@@ -27,15 +30,11 @@ import com.pingcap.tikv.kvproto.Metapb.Store;
 import com.pingcap.tikv.region.RegionManager;
 import com.pingcap.tikv.region.TiRegion;
 import gnu.trove.list.array.TLongArrayList;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.pingcap.tikv.util.KeyRangeUtils.formatByteString;
-import static java.util.Objects.requireNonNull;
 
 public class RangeSplitter {
   public static class RegionTask implements Serializable {
@@ -74,16 +73,13 @@ public class RangeSplitter {
     @Override
     public String toString() {
       StringBuilder sb = new StringBuilder();
-      sb.append("[Region:");
-      sb.append("id=").append(region.getId());
-      sb.append(" start=").append(formatByteString(region.getStartKey()));
-      sb.append(" end=").append(formatByteString(region.getEndKey()));
-      sb.append("]");
+      sb.append(String.format("Region [%s]", region));
+      sb.append(" ");
 
       for (KeyRange range : ranges) {
         sb.append(
             String.format(
-                "Range Start: %s, Range End: %s",
+                "Range Start: [%s] Range End: [%s]",
                 formatByteString(range.getStart()), formatByteString(range.getEnd())));
       }
 


### PR DESCRIPTION
1. Add PD cache debug message.
2. Replace LoadingCache for hashmap which does not have a size upper bound.
3. Make unknown error throw instead of swallow.
4. Disregard new region list returned by stale error since they are not reliable if stale too far away (for now caused by not updating driver cache when executor error handled which will be addressed later)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/170)
<!-- Reviewable:end -->
