### PR TITLE
Fix cast AIOB error

### DIFF
--- a/src/main/java/com/pingcap/tikv/operation/transformer/Cast.java
+++ b/src/main/java/com/pingcap/tikv/operation/transformer/Cast.java
@@ -30,7 +30,8 @@ public class Cast extends NoOp {
   public void set(Object value, Row row, int pos) {
     Object casted;
     if (value == null) {
-      row.set(row.fieldCount(), targetDataType, null);
+      row.set(pos, targetDataType, null);
+      return;
     }
     if (targetDataType instanceof IntegerType) {
       casted = castToLong(value);


### PR DESCRIPTION
Original `row.set(row.fieldCount(), targetDataType, null);` will surely cause AIOB error since `row.fieldCount()` number is out of bound.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/183)
<!-- Reviewable:end -->
