### PR TITLE
Fix TiConstant dataType mapping issue

### DIFF
--- a/src/main/java/com/pingcap/tikv/expression/TiConstant.java
+++ b/src/main/java/com/pingcap/tikv/expression/TiConstant.java
@@ -26,7 +26,8 @@ import java.math.BigDecimal;
 import java.util.Objects;
 
 import static com.pingcap.tikv.types.Types.*;
-
+// Refactor needed.
+// Refer to https://github.com/pingcap/tipb/blob/master/go-tipb/expression.pb.go
 // TODO: This might need a refactor to accept an DataType?
 public class TiConstant implements TiExpr {
   private Object value;
@@ -97,7 +98,7 @@ public class TiConstant implements TiExpr {
     } else if (value instanceof Float) {
       return DataTypeFactory.of(TYPE_FLOAT);
     } else if (value instanceof Double) {
-      return DataTypeFactory.of(TYPE_NEW_DECIMAL);
+      return DataTypeFactory.of(TYPE_DOUBLE);
     } else {
       throw new TiExpressionException("Constant type not supported.");
     }

--- a/src/main/java/com/pingcap/tikv/expression/scalar/TiScalarFunction.java
+++ b/src/main/java/com/pingcap/tikv/expression/scalar/TiScalarFunction.java
@@ -46,6 +46,11 @@ public abstract class TiScalarFunction extends TiFunctionExpression {
     );
   }
 
+  @Override
+  public String getName() {
+    return getSignature().name();
+  }
+
   private DataType getArgType() {
     if (args.isEmpty()) {
       throw new TiExpressionException(


### PR DESCRIPTION
We should map `java.lang.Double` to `TPYE_DOUBLE` instead of `TYPE_NEW_DECIMAL`.

Refer to https://github.com/pingcap/tispark/issues/132

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/191)
<!-- Reviewable:end -->
