### PR TITLE
add support for covering index

### DIFF
--- a/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
+++ b/src/main/java/com/pingcap/tikv/meta/TiColumnInfo.java
@@ -25,6 +25,7 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.types.DataType;
 import com.pingcap.tikv.types.DataType.EncodeType;
 import com.pingcap.tikv.types.DataTypeFactory;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -107,7 +108,7 @@ public class TiColumnInfo implements Serializable {
     return comment;
   }
 
-  boolean isPrimaryKey() {
+  public boolean isPrimaryKey() {
     return isPrimaryKey;
   }
 

--- a/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
+++ b/src/main/java/com/pingcap/tikv/predicates/ScanBuilder.java
@@ -93,7 +93,7 @@ public class ScanBuilder {
     return minPlan;
   }
 
-  private ScanPlan buildTableScan(List<TiExpr> conditions, TiTableInfo table) {
+  public ScanPlan buildTableScan(List<TiExpr> conditions, TiTableInfo table) {
     TiIndexInfo pkIndex = TiIndexInfo.generateFakePrimaryKeyIndex(table);
     return buildScan(conditions, pkIndex, table);
   }
@@ -305,7 +305,7 @@ public class ScanBuilder {
     return ranges;
   }
 
-  public boolean isCoveringIndex(List<TiColumnInfo> columns, TiIndexInfo indexColumns, boolean pkIsHandle) {
+  private boolean isCoveringIndex(List<TiColumnInfo> columns, TiIndexInfo indexColumns, boolean pkIsHandle) {
     for (TiColumnInfo colInfo: columns) {
       if (pkIsHandle && colInfo.isPrimaryKey()) {
         continue;

--- a/src/main/java/com/pingcap/tikv/types/DataType.java
+++ b/src/main/java/com/pingcap/tikv/types/DataType.java
@@ -15,17 +15,6 @@
 
 package com.pingcap.tikv.types;
 
-import static com.pingcap.tikv.types.Types.AutoIncrementFlag;
-import static com.pingcap.tikv.types.Types.MultipleKeyFlag;
-import static com.pingcap.tikv.types.Types.NoDefaultValueFlag;
-import static com.pingcap.tikv.types.Types.NotNullFlag;
-import static com.pingcap.tikv.types.Types.OnUpdateNowFlag;
-import static com.pingcap.tikv.types.Types.PriKeyFlag;
-import static com.pingcap.tikv.types.Types.TimestampFlag;
-import static com.pingcap.tikv.types.Types.UniqueKeyFlag;
-import static com.pingcap.tikv.types.Types.UnsignedFlag;
-import static com.pingcap.tikv.types.Types.ZerofillFlag;
-
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.pingcap.tikv.codec.CodecDataInput;
@@ -33,8 +22,11 @@ import com.pingcap.tikv.codec.CodecDataOutput;
 import com.pingcap.tikv.meta.Collation;
 import com.pingcap.tikv.meta.TiColumnInfo;
 import com.pingcap.tikv.row.Row;
+
 import java.io.Serializable;
 import java.util.List;
+
+import static com.pingcap.tikv.types.Types.*;
 
 /** Base Type for encoding and decoding TiDB row information. */
 public abstract class DataType implements Serializable {
@@ -231,7 +223,7 @@ public abstract class DataType implements Serializable {
     return tp;
   }
 
-  public static boolean hasNullFlag(int flag) {
+  public static boolean hasNotNullFlag(int flag) {
     return (flag & NotNullFlag) > 0;
   }
 
@@ -252,6 +244,10 @@ public abstract class DataType implements Serializable {
   }
 
   public static boolean hasBinaryFlag(int flag) {
+    return (flag & BinaryFlag) > 0;
+  }
+
+  public static boolean hasPriKeyFlag(int flag) {
     return (flag & PriKeyFlag) > 0;
   }
 


### PR DESCRIPTION
By using covering index, we can avoid double read and ineffective table scan.

consistent with [this pr](https://github.com/pingcap/tispark/pull/148)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tikv-client-lib-java/206)
<!-- Reviewable:end -->
